### PR TITLE
fix: do not continuously recompile HTML templates during `serve`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,9 @@ jobs:
         run: nix flake check
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: nix develop .#devShells.default -c cargo build --release
+        run: nix develop . -c cargo build --release
       - name: Run
-        run: nix develop .#devShells.default -c cargo run -- --version
+        run: nix develop . -c cargo run -- --version
 
   macos:
     runs-on: macos-latest
@@ -63,6 +63,6 @@ jobs:
         run: nix flake check
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: nix develop .#devShells.default -c cargo build --release
+        run: nix develop . -c cargo build --release
       - name: Run
-        run: nix develop .#devShells.default -c cargo run -- --version
+        run: nix develop . -c cargo run -- --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,4 +39,4 @@ jobs:
         run: nix flake check
       - uses: Swatinem/rust-cache@v2
       - name: Test codebase
-        run: nix develop .#devShells.default -c cargo nextest run --features ci
+        run: nix develop . -c cargo nextest run --features ci

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc904b9bbefcadbd8e3a9fb0d464a9b979de6324c03b3c663e8994f46a5be36"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +942,7 @@ dependencies = [
  "indoc",
  "mockall",
  "notify",
+ "notify-debouncer-full",
  "open",
  "rust-norg",
  "tera",
@@ -958,6 +968,19 @@ dependencies = [
  "notify-types",
  "walkdir",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d88b1a7538054351c8258338df7c931a590513fb3745e8c15eb9ff4199b8d1"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
@@ -339,7 +345,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "crossterm_winapi",
  "parking_lot",
  "rustix",
@@ -420,6 +426,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -430,6 +448,15 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "futures-channel"
@@ -516,7 +543,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "ignore",
  "walkdir",
 ]
@@ -700,6 +727,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.8.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +797,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,6 +833,17 @@ name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -811,6 +889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -853,6 +932,7 @@ dependencies = [
  "hyper",
  "indoc",
  "mockall",
+ "notify",
  "open",
  "rust-norg",
  "tera",
@@ -860,6 +940,31 @@ dependencies = [
  "toml",
  "whoami",
 ]
+
+[[package]]
+name = "notify"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+dependencies = [
+ "bitflags 2.8.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "num-traits"
@@ -1133,7 +1238,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -1188,7 +1293,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "errno",
  "libc",
  "linux-raw-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ open = "5.3.2"
 indoc = "2.0.5"
 html-escape = "0.2.13"
 notify = "8.0.0"
+notify-debouncer-full = "0.5.0"
 
 [profile.optimized]   # Size optimizations that will hurt build speed
 inherits = "release"  # Which profile we inherit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ whoami = "1.5.2"
 open = "5.3.2"
 indoc = "2.0.5"
 html-escape = "0.2.13"
+notify = "8.0.0"
 
 [profile.optimized]   # Size optimizations that will hurt build speed
 inherits = "release"  # Which profile we inherit

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -71,7 +71,9 @@ async fn create_html_templates(root: &str) -> Result<()> {
             {{% endblock head %}}
         </head>
         <body>
-            <div id="content">{{% block content %}}{{% endblock content %}}</div>
+            <div id="content">
+                {{{{ content | safe }}}}
+            </div>
             <div id="footer">
                 {{% block footer %}}
                 &copy; Copyright {} by {}.


### PR DESCRIPTION
This change creates a new instance of Tera in the `serve` function instead of starting a new one every time a new request is made to the server, thus avoiding unnecessary reloads of templates while also implementing a file watcher system using `notify` and a debouncer using `notify-debouncer-full` to avoid spamming the stdout when modifying files.

Edit: this PR also uses Tera's `Context` to render the contents of `norg` files directly into the `base.html` template to avoid having to create a `current.html` template in memory for each request.