### PR TITLE
feat(config): implement structured site configuration and enhance template system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,7 @@ dependencies = [
  "notify-debouncer-full",
  "open",
  "rust-norg",
+ "serde",
  "tera",
  "tokio",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ indoc = "2.0.5"
 html-escape = "0.2.13"
 notify = "8.0.0"
 notify-debouncer-full = "0.5.0"
+serde = { version = "1.0.217", features = ["derive"] }
 
 [profile.optimized]   # Size optimizations that will hurt build speed
 inherits = "release"  # Which profile we inherit

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -11,10 +11,12 @@ async fn create_config(root: &str) -> Result<()> {
         r#"
         rootUrl = '{}'
         language = '{}'
-        title = '{}'"#,
+        title = '{}'
+        author = '{}'"#,
         "http://localhost:3030", // this is the default port
         "en-us",
-        root.to_owned()
+        root.to_owned(),
+        whoami::username()
     );
     // TBD: add Windows separator support
     fs::write(root.to_owned() + "/norgolith.toml", site_config).await?;
@@ -57,34 +59,7 @@ async fn create_index_norg(root: &str) -> Result<()> {
 /// Create basic HTML templates
 async fn create_html_templates(root: &str) -> Result<()> {
     // TODO: add 'head.html', 'footer.html'
-    // TODO: extract some information like language and title from the site config?
-    let base_template = formatdoc!(
-        r#"
-        <!DOCTYPE html>
-        <html lang="en">
-        <head>
-            {{% block head %}}
-            <meta charset="UTF-8" />
-            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            <link rel="stylesheet" href="style.css" />
-            <title>{{% block title %}}{{% endblock title %}} - {}</title>
-            {{% endblock head %}}
-        </head>
-        <body>
-            <div id="content">
-                {{{{ content | safe }}}}
-            </div>
-            <div id="footer">
-                {{% block footer %}}
-                &copy; Copyright {} by {}.
-                {{% endblock footer %}}
-            </div>
-        </body>
-        </html>"#,
-        root.to_owned(),
-        chrono::offset::Local::now().format("%Y"),
-        whoami::username()
-    );
+    let base_template = include_str!("../templates/base.html");
     // TBD: add Windows separator support
     fs::write(root.to_owned() + "/templates/base.html", base_template).await?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SiteConfig {
+    #[serde(rename = "rootUrl")]
+    root_url: String,
+    language: String,
+    title: String,
+    author: String,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
 mod cli;
 mod cmd;
+mod config;
 mod converter;
 mod fs;
 mod net;
+mod tera_functions;
 
 use eyre::Result;
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="{{ config.language }}">
+<head>
+    {% block head %}
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css" />
+    <title>{% block title %}{% endblock title %} - {{ config.title }}</title>
+    {% endblock head %}
+</head>
+<body>
+    <div id="content">
+        {{ content | safe }}
+    </div>
+    <div id="footer">
+        {% block footer %}
+        &copy; Copyright {{ now(format="%Y") }} by {{ config.author }}.
+        {% endblock footer %}
+    </div>
+</body>
+</html>

--- a/src/tera_functions.rs
+++ b/src/tera_functions.rs
@@ -1,0 +1,18 @@
+use tera::{Function, Value, Error};
+use std::collections::HashMap;
+use eyre::Result;
+
+/// Now function
+/// Template usage: {{ now(format="%A, %B %d") }} → "Thursday, October 05"
+pub struct NowFunction;
+impl Function for NowFunction {
+    fn call(&self, args: &HashMap<String, Value>) -> Result<Value, Error> {
+        let format = match args.get("format") {
+            Some(v) => v.as_str().ok_or(tera::Error::msg("`format` must be a string"))?,
+            None => "%Y-%m-%d %H:%M:%S", // Default format
+        };
+
+        let now = chrono::Local::now();
+        Ok(Value::String(now.format(format).to_string()))
+    }
+}


### PR DESCRIPTION
- Add `SiteConfig` struct with serde-derived serialization/deserialization

- Integrate site configuration into server state and template rendering context

- Create dedicated base template file with dynamic config values

- Add custom Tera `now` function for datetime formatting in templates

- Include `author` field in generated site configuration during init

- Preserve template directory structure in `init` command

- Update template to use config values for `language`, `title`, and `author`

- Add proper error handling for config file parsing

- Register custom tera functions in template engine initialization

- Centralize template assets using `include_str!` for better maintenance

---

Resolves #5