### PR TITLE
ref!: rename binary from `norgolith` to `lith`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,9 @@ keywords = ["static", "site", "generator", "blog", "norg"]
 
 include = ["src/**/*", "LICENSE", "README.md"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "lith"
+path = "src/main.rs"
 
 [dependencies]
 chrono = "0.4.39"

--- a/README.md
+++ b/README.md
@@ -44,26 +44,27 @@ solution for crafting static websites from Norg content. Here's what makes Norgo
 
 ## 📚 Usage
 
-Compile the project using the `optimized` Cargo profile (recommended).
+Compile the project using the `optimized` Cargo profile (recommended). Note that the produced binary
+is called `lith` and not `norgolith`, this is for ergonomic reasons.
 
 ```
-$ cargo build --profile optimized && ./target/optimized/norgolith --help
+$ cargo build --profile optimized && ./target/optimized/lith --help
 
 The monolithic Norg static site generator
 
-Usage: norgolith <COMMAND>
+Usage: lith [OPTIONS] <COMMAND>
 
 Commands:
   init   Initialize a new Norgolith site
   serve  Build a site for development
-  new    Create a new asset in the site (e.g. 'new -k content post1.norg' ->
-         'content/post1.norg') and open it using your preferred system editor
+  new    Create a new asset in the site and optionally open it using your preferred          system editor. e.g. 'new -k content post1.norg' -> 'content/post1.norg'
   build  Build a site for production
   help   Print this message or the help of the given subcommand(s)
 
 Options:
-  -v, --version  Print version
-  -h, --help     Print help
+  -v, --version            Print version
+  -d, --dir <PROJECT_DIR>  Operate on the project in the given directory
+  -h, --help               Print help
 ```
 
 ## ⚡ Install


### PR DESCRIPTION
After a small discussion to decide a shorter name for the produced Norgolith binary, we ended up choosing `lith`. It is a clever, ergonomic and meaningful shortening of "Norgolith" that carries both technical and symbolic weight to the project.

The suffix "-lith" comes directly from the full name Norgolith, which itself derives from "monolithic", that is a key descriptor for the project. "Lith" also originates from the Greek word lithos, meaning "stone" or "rock", which ties into the idea of stability, durability, and permanence—traits that align with the Norgolith project README description.

Typing any Norgolith command will be effortless now, e.g. `lith serve` vs `norgolith serve`.