### PR TITLE
feat(serve): add custom templates loading

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -39,6 +39,7 @@ async fn create_index_norg(root: &str) -> Result<()> {
         categories: []
         created: {}
         updated: {}
+        layout: base
         draft: true
         version: 1.1.1
         @end

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -93,7 +93,8 @@ pub async fn new(kind: &str, name: &str, open: bool) -> Result<()> {
 
     // Find Norgolith site root directory
     let mut current_dir = std::env::current_dir()?;
-    let found_site_root = fs::find_in_previous_dirs("file", "norgolith.toml", &mut current_dir).await?;
+    let found_site_root =
+        fs::find_in_previous_dirs("file", "norgolith.toml", &mut current_dir).await?;
 
     let site_root = match found_site_root {
         Some(mut root) => {

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -266,14 +266,18 @@ async fn handle_request(req: Request<Body>, state: Arc<ServerState>) -> Result<R
                     }
                 };
 
+                // Get the layout (template) to render the content, fallback to base if the metadata field was not found.
+                let layout = metadata.get("layout").unwrap_or(&toml::Value::from("base")).as_str().unwrap().to_owned();
+
                 // Build template context
                 let mut context = Context::new();
                 context.insert("content", &path_contents);
                 context.insert("config", &state.config);
                 context.insert("metadata", &metadata);
 
+                // Get the template to use for rendering
                 let tera = state.tera.read().await;
-                tera.render("base.html", &context)
+                tera.render(&(layout + ".html"), &context)
                     .map(|body| {
                         let mut response = Response::new(Body::from(body));
                         response.headers_mut().insert(

--- a/src/converter/meta.rs
+++ b/src/converter/meta.rs
@@ -1,7 +1,7 @@
+use eyre::{Error, Result};
 use rust_norg::metadata::{parse_metadata, NorgMeta};
 use std::str::FromStr;
 use toml::{self, value::Datetime};
-use eyre::{Error, Result};
 
 fn parse_str_to_toml_value(s: &str) -> Result<toml::Value, MetaToTomlError> {
     if let Ok(datetime) = Datetime::from_str(s) {
@@ -90,11 +90,9 @@ fn extract_meta(input: &str) -> String {
 /// Extracts and converts Norg metadata to TOML format
 pub fn convert(document: &str) -> Result<toml::Value, Error> {
     let extracted_meta = extract_meta(document);
-    let meta = parse_metadata(&extracted_meta)
-        .expect("Failed to parse metadata");
+    let meta = parse_metadata(&extracted_meta).expect("Failed to parse metadata");
 
-    let toml_value = norg_meta_to_toml(&meta)
-        .expect("Failed to convert metadata to TOML");
+    let toml_value = norg_meta_to_toml(&meta).expect("Failed to convert metadata to TOML");
 
     Ok(toml_value)
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,7 +7,11 @@ use tokio::fs::{metadata, read_dir};
 use tokio::fs::{canonicalize, create_dir, remove_dir, remove_file, File};
 
 /// Find a given file or directory in the current working directory and its parent directories recursively
-pub async fn find_in_previous_dirs(kind: &str, filename: &str, current_dir: &mut PathBuf) -> Result<Option<PathBuf>> {
+pub async fn find_in_previous_dirs(
+    kind: &str,
+    filename: &str,
+    current_dir: &mut PathBuf,
+) -> Result<Option<PathBuf>> {
     loop {
         // Check if the file|dir exists in the current directory first
         let path = current_dir.join(filename);
@@ -74,7 +78,12 @@ mod tests {
         std::env::set_current_dir(canonicalize(test_directory.clone()).await?)?;
 
         // Look for the temporal test file
-        let result = find_in_previous_dirs("file", test_file, &mut previous_dir.join(test_directory.clone())).await;
+        let result = find_in_previous_dirs(
+            "file",
+            test_file,
+            &mut previous_dir.join(test_directory.clone()),
+        )
+        .await;
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(previous_dir.join(test_file)));
 
@@ -109,7 +118,12 @@ mod tests {
 
         // Look for the temporal directory
         let mut current_dir = std::env::current_dir()?;
-        let result = find_in_previous_dirs("dir", test_directory.clone().to_str().unwrap(), &mut current_dir).await;
+        let result = find_in_previous_dirs(
+            "dir",
+            test_directory.clone().to_str().unwrap(),
+            &mut current_dir,
+        )
+        .await;
         assert!(result.is_ok());
         assert_eq!(
             result.unwrap(),

--- a/src/tera_functions.rs
+++ b/src/tera_functions.rs
@@ -1,6 +1,6 @@
-use tera::{Function, Value, Error};
-use std::collections::HashMap;
 use eyre::Result;
+use std::collections::HashMap;
+use tera::{Error, Function, Value};
 
 /// Now function
 /// Template usage: {{ now(format="%A, %B %d") }} → "Thursday, October 05"
@@ -8,7 +8,9 @@ pub struct NowFunction;
 impl Function for NowFunction {
     fn call(&self, args: &HashMap<String, Value>) -> Result<Value, Error> {
         let format = match args.get("format") {
-            Some(v) => v.as_str().ok_or(tera::Error::msg("`format` must be a string"))?,
+            Some(v) => v
+                .as_str()
+                .ok_or(tera::Error::msg("`format` must be a string"))?,
             None => "%Y-%m-%d %H:%M:%S", // Default format
         };
 


### PR DESCRIPTION
Norgolith will now attempt to load a custom `template` based on the `layout` metadata field in the norg files.

I haven't tested with nested templates in directories (e.g. `layout: foo/bar` -> `templates/foo/bar.html`), but the way templates are currently loaded it should work fine.