### PR TITLE
feat(init): add basic css styling file for demo purposes, move `init`…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
  "crossterm",
  "strum",
  "strum_macros",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1314,11 +1314,12 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "rust-norg"
 version = "0.1.0"
-source = "git+https://github.com/nvim-neorg/rust-norg?branch=main#be7117a4aea5df098753e3f42f6814f94bedcd02"
+source = "git+https://github.com/nvim-neorg/rust-norg?branch=main#79673015447b62d021d57b92f80be1454fe5cf83"
 dependencies = [
  "chumsky",
  "itertools",
  "serde",
+ "textwrap",
  "unicode_categories",
 ]
 
@@ -1467,6 +1468,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,6 +1569,17 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "thiserror"
@@ -1762,6 +1780,18 @@ name = "unicode-ident"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -26,6 +26,9 @@ async fn create_config(root: &str) -> Result<()> {
 
 /// Create a basic hello world norg document
 async fn create_index_norg(root: &str) -> Result<()> {
+    // TODO: move this to src/resources/content and load it using `include_str!`
+    //
+    // let norg_index = format_args!(include_str!(".../index.norg"), foo="test");
     let creation_date =
         chrono::offset::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, false);
     let norg_metadata = formatdoc!(
@@ -60,9 +63,16 @@ async fn create_index_norg(root: &str) -> Result<()> {
 /// Create basic HTML templates
 async fn create_html_templates(root: &str) -> Result<()> {
     // TODO: add 'head.html', 'footer.html'
-    let base_template = include_str!("../templates/base.html");
+    let base_template = include_str!("../resources/templates/base.html");
     // TBD: add Windows separator support
     fs::write(root.to_owned() + "/templates/base.html", base_template).await?;
+
+    Ok(())
+}
+
+async fn create_css(root: &str) -> Result<()> {
+    let base_style = include_str!("../resources/assets/style.css");
+    fs::write(root.to_owned() + "/assets/style.css", base_style).await?;
 
     Ok(())
 }
@@ -93,10 +103,11 @@ pub async fn init(name: &str) -> Result<()> {
         create_directories(name).await?;
 
         // Create initial files
-        // TBD: Basic HTML templates and start work with Tera
+        // TBD: Basic HTML templates
         create_config(name).await?;
         create_index_norg(name).await?;
         create_html_templates(name).await?;
+        create_css(name).await?;
 
         // Get the canonical (absolute) path to the new site root
         let path = fs::canonicalize(name).await?;

--- a/src/resources/assets/style.css
+++ b/src/resources/assets/style.css
@@ -1,0 +1,50 @@
+/* Default fonts */
+@font-face {
+  font-family: 'Inter';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url(https://cdn.jsdelivr.net/fontsource/fonts/inter:vf@latest/latin-wght-normal.woff2) format('woff2-variations');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+@font-face {
+  font-family: 'JetBrains Mono';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 800;
+  src: url(https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono:vf@latest/latin-wght-normal.woff2) format('woff2-variations');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+@font-face {
+  font-family: 'JetBrains Mono Italic';
+  font-style: italic;
+  font-display: swap;
+  font-weight: 100 800;
+  src: url(https://cdn.jsdelivr.net/fontsource/fonts/jetbrains-mono:vf@latest/latin-wght-italic.woff2) format('woff2-variations');
+  unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+}
+
+/* Styling */
+* {
+    box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+}
+
+body {
+    color: white;
+    background-color: #202030;
+    padding: 0 20px;
+    width: auto;
+    font-family: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
+pre > code,
+code {
+    font-family: 'JetBrains Mono', monospace;
+    background-color: #303040;
+    border-radius: 6px;
+    padding: 0px 2px;
+}

--- a/src/resources/templates/base.html
+++ b/src/resources/templates/base.html
@@ -13,7 +13,12 @@
     <meta name="keywords" content="{{ metadata.categories | join(sep=", ") }}" />
     {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="style.css" />
+    {# Highlight.js #}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+    <script>hljs.highlightAll();</script>
+    {# User-defined styling #}
+    <link rel="stylesheet" href="/assets/style.css" />
     <title>{% block title %}{{ metadata.title | title }}{% endblock title %} - {{ config.title | title }}</title>
     {% endblock head %}
 </head>


### PR DESCRIPTION
… command assets (templates, css) to a separate `resources` directory and adjust default base template

- The demo CSS file imports both Inter and JetBrains Mono fonts from fontsource

- The base html template now also imports Highlight.js library from CDN