### PR TITLE
feat(templates)!: implement structured template inheritance and default layouts

### DIFF
--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -315,10 +315,10 @@ async fn handle_request(req: Request<Body>, state: Arc<ServerState>) -> Result<R
                     }
                 };
 
-                // Get the layout (template) to render the content, fallback to base if the metadata field was not found.
+                // Get the layout (template) to render the content, fallback to default if the metadata field was not found.
                 let layout = metadata
                     .get("layout")
-                    .unwrap_or(&toml::Value::from("base"))
+                    .unwrap_or(&toml::Value::from("default"))
                     .as_str()
                     .unwrap()
                     .to_owned();

--- a/src/resources/content/index.norg
+++ b/src/resources/content/index.norg
@@ -1,0 +1,17 @@
+@document.meta
+title: Welcome to Norgolith
+description: This is a static site made using norgolith.
+authors: [
+  {username}
+]
+categories: []
+created: {created_at}
+updated: {updated_at}
+layout: default
+draft: true
+version: 1.1.1
+@end
+
+* Welcome to Norgolith
+  Lorem ipsum dolor sitamet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+  labore et dolore magna aliqua. Lobortis scelerisque fermentum dui faucibus in ornare.

--- a/src/resources/templates/base.html
+++ b/src/resources/templates/base.html
@@ -19,13 +19,11 @@
     <script>hljs.highlightAll();</script>
     {# User-defined styling #}
     <link rel="stylesheet" href="/assets/style.css" />
-    <title>{% block title %}{{ metadata.title | title }}{% endblock title %} - {{ config.title | title }}</title>
+    <title>{% block title %}{% endblock title %} - {{ config.title | title }}</title>
     {% endblock head %}
 </head>
 <body>
-    <div id="content">
-        {{ content | safe }}
-    </div>
+    <div id="content">{% block content %}{% endblock content %}</div>
     <div id="footer">
         {% block footer %}
         &copy; Copyright {{ now(format="%Y") }} by {{ config.author }}.

--- a/src/resources/templates/default.html
+++ b/src/resources/templates/default.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}{{ metadata.title | title }}{% endblock title %}
+{% block content %}
+    {{ content | safe }}
+{% endblock content %}


### PR DESCRIPTION
- Add template inheritance system with base/default HTML structure

- Create separate template files in resources directory

  - Add `default.html` as primary content template extending `base.html`

  - Move `index.norg` content to dedicated resource file

- Implement dynamic template loading during site initialization

- Update init command to create multiple template files

  - Create default template structure with base/default separation

  - Use resource embedding for template/content files

- Change default layout from `base` to `default` in server logic

- Implement proper template blocks (title/content) for inheritance

- Add dynamic metadata injection in default template title

- Improve new site initialization content with proper metadata examples

Note: This is a breaking change because it changes the default layout.