### PR TITLE
feat: add syntax highlighting configuration options

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -15,7 +15,12 @@ async fn create_config(root: &str) -> Result<()> {
         rootUrl = '{}'
         language = '{}'
         title = '{}'
-        author = '{}'"#,
+        author = '{}'
+
+        # Code blocks highlighting
+        [highlighter]
+        enable = false
+        # engine = 'prism' # Can be 'prism' or 'hljs'. Defaults to 'prism'"#,
         "http://localhost:3030", // this is the default port
         "en-us",
         root.to_owned(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,17 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+struct SiteConfigHighlighter {
+    enable: bool,
+    engine: Option<String>, // fallbacks to prism if not defined
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SiteConfig {
     #[serde(rename = "rootUrl")]
     root_url: String,
     language: String,
     title: String,
     author: String,
+    highlighter: Option<SiteConfigHighlighter>,
 }

--- a/src/resources/templates/base.html
+++ b/src/resources/templates/base.html
@@ -13,10 +13,36 @@
     <meta name="keywords" content="{{ metadata.categories | join(sep=", ") }}" />
     {% endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    {# Highlight.js #}
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
-    <script>hljs.highlightAll();</script>
+    {% if config.highlighter is defined and config.highlighter.enable %}
+      {# If highlighter is enabled but the engine is not defined then fallback to prismjs #}
+      {% if config.highlighter.engine is not string or config.highlighter.engine == "prism" %}
+        {# PrismJS #}
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism-themes/1.9.0/prism-one-dark.min.css" />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+      {% elif config.highlighter.engine is defined
+          and config.highlighter.engine == "hljs" %}
+        {# Highlight.js #}
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/atom-one-dark.min.css">
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+        <script>hljs.highlightAll();</script> #}
+        {# Enable this one instead if you want all the `<code>` tags to be highlighted
+        <script>
+          document.addEventListener("DOMContentLoaded", (event) => {
+            document.querySelectorAll("code").forEach((block) => {
+              hljs.highlightBlock(block);
+            });
+          });
+        </script>
+        #}
+      {% elif config.highlighter.engine is string
+          and config.highlighter.engine not in ["prism", "hljs"] %}
+        <script>
+          window.alert("Warning: highlighter is enabled in the site configuration but its engine is not 'prism' nor 'hljs'");
+        </script>
+      {% endif %}
+    {% endif %}
     {# User-defined styling #}
     <link rel="stylesheet" href="/assets/style.css" />
     <title>{% block title %}{% endblock title %} - {{ config.title | title }}</title>


### PR DESCRIPTION
- Implement `highlighter` config section in site configuration

- Add `PrismJS` and `Highlight.js` loading logic to base template

- Support engine selection between `prism`/`hljs` in templates

- Include CDN resources for both highlighting engines

- Add error handling for invalid engine selection through window alerts

- Update `init` command template with default highlighting config

- Maintain backwards compatibility with highlighting disabled by default

Closes #37 