### PR TITLE
feat: ship TailwindCSS Play CDN by default

### DIFF
--- a/src/resources/content/index.norg
+++ b/src/resources/content/index.norg
@@ -12,6 +12,7 @@ draft: true
 version: 1.1.1
 @end
 
++html.class text-3xl font-bold
 * Welcome to Norgolith
   Lorem ipsum dolor sitamet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
   labore et dolore magna aliqua. Lobortis scelerisque fermentum dui faucibus in ornare.

--- a/src/resources/templates/base.html
+++ b/src/resources/templates/base.html
@@ -43,6 +43,8 @@
         </script>
       {% endif %}
     {% endif %}
+    {# Tailwind CDN, replace with the Tailwind standalone CLI for production! #}
+    <script src="https://unpkg.com/@tailwindcss/browser@4"></script>
     {# User-defined styling #}
     <link rel="stylesheet" href="/assets/style.css" />
     <title>{% block title %}{% endblock title %} - {{ config.title | title }}</title>


### PR DESCRIPTION
Note that the Play CDN is meant to be used only for development purposes, and is not intended for production. A proper Tailwind CLI setup should be used later by the end user.