### PR TITLE
fix(converter): isolate list item content from parent carryover tags

### DIFF
--- a/src/converter/html.rs
+++ b/src/converter/html.rs
@@ -331,7 +331,11 @@ impl NorgToHtml for NorgAST {
             } => {
                 // HACK: 'text' is actually a 'Box<NorgASTFlat>' value. It should be converted into a `ParagraphSegment` later in the rust-norg parser
                 let mod_text = if let NorgASTFlat::Paragraph(s) = *text.clone() {
-                    paragraph_to_string(&s, &strong_carry, &mut weak_carry)
+                    let strong = Vec::<CarryOverTag>::new();
+                    let mut weak = Vec::<CarryOverTag>::new();
+                    // HACK: we are passing empty carryover vectors here because otherwise
+                    // the HTML carryovers meant for the lists are used for its internal content instead
+                    paragraph_to_string(&s, &strong, &mut weak)
                 } else {
                     unreachable!();
                 };


### PR DESCRIPTION
- Prevent list-level HTML carryover tags from affecting nested content

- Create clean carryover context for list item text conversion

- Resolve unintended attribute inheritance in list structures

- Maintain proper HTML attribute scoping within list items