### PR TITLE
feat: handle `draft` content properly

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -67,6 +67,15 @@ async fn generate_public_build(
                             }
                         };
 
+                    // Do not try to build draft content for production builds
+                    if toml::Value::as_bool(
+                        metadata.get("draft").unwrap_or(&toml::Value::from(false)),
+                    )
+                    .expect("draft metadata field should be a boolean")
+                    {
+                        return;
+                    }
+
                     // Get the layout (template) to render the content, fallback to default if the metadata field was not found.
                     let layout = metadata
                         .get("layout")
@@ -196,7 +205,7 @@ pub async fn build(minify: bool) -> Result<()> {
         prepare_build_directory(Path::new(&root_dir)).await?;
 
         // Convert the norg documents to html
-        shared::convert_content(&content_dir).await?;
+        shared::convert_content(&content_dir, false).await?;
 
         // Clean up orphaned files before building the site
         shared::cleanup_orphaned_build_files(&content_dir).await?;

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -332,7 +332,7 @@ async fn handle_request(req: Request<Body>, state: Arc<ServerState>) -> Result<R
     }
 }
 
-pub async fn serve(port: u16, open: bool) -> Result<()> {
+pub async fn serve(port: u16, drafts: bool, open: bool) -> Result<()> {
     // Try to find a 'norgolith.toml' file in the current working directory and its parents
     let mut current_dir = std::env::current_dir()?;
     let found_site_root =
@@ -501,6 +501,7 @@ pub async fn serve(port: u16, open: bool) -> Result<()> {
                                 match shared::convert_document(
                                     &rebuild_document_path,
                                     &state.content_dir,
+                                    drafts
                                 )
                                 .await
                                 {
@@ -563,7 +564,7 @@ pub async fn serve(port: u16, open: bool) -> Result<()> {
         let uri = format!("http://localhost:{}/", port);
 
         // Convert the norg documents to html
-        shared::convert_content(&content_dir).await?;
+        shared::convert_content(&content_dir, drafts).await?;
 
         // Clean up orphaned files before starting server
         shared::cleanup_orphaned_build_files(&content_dir).await?;


### PR DESCRIPTION
`lith serve` will build draft content by default (as if `--drafts` flag has been passed to the command). To disable this behaviour, use `--no-drafts`.

`lith build` will completely ignore any draft content.

Closes #56