### PR TITLE
feat(themes): implement theme management system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "comfy-table"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1698,7 @@ dependencies = [
  "rust-norg",
  "semver",
  "serde",
+ "spinoff",
  "tempfile",
  "tera",
  "tokio",
@@ -2489,6 +2500,17 @@ checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "spinoff"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20aa2ed67fbb202e7b716ff8bfc6571dd9301617767380197d701c31124e88f6"
+dependencies = [
+ "colored",
+ "once_cell",
+ "paste",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -35,7 +35,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -249,6 +249,8 @@ version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -573,6 +575,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +639,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "file-id"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +670,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fragile"
@@ -744,7 +772,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -752,6 +792,21 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
+dependencies = [
+ "bitflags 2.8.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "globset"
@@ -954,6 +1009,145 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "ignore"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1265,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,6 +1316,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.0+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1347,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "libssh2-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9b68e50e6e0b26f672573834882eb57759f6db9b3be2ea3c35c91188bb4eaa"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "lightningcss"
 version = "1.0.0-alpha.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,7 +1385,7 @@ dependencies = [
  "cssparser-color",
  "dashmap",
  "data-encoding",
- "getrandom",
+ "getrandom 0.2.15",
  "indexmap",
  "itertools 0.10.5",
  "lazy_static",
@@ -1173,6 +1416,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1293,7 +1542,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -1343,6 +1592,7 @@ dependencies = [
  "css-minify",
  "eyre",
  "futures-util",
+ "git2",
  "html-escape",
  "hyper",
  "indoc",
@@ -1356,7 +1606,9 @@ dependencies = [
  "open",
  "regex",
  "rust-norg",
+ "semver",
  "serde",
+ "tempfile",
  "tera",
  "tokio",
  "tokio-tungstenite",
@@ -1446,6 +1698,24 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1670,6 +1940,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,7 +2066,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -1966,6 +2242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "semver"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,6 +2391,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "stacker"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2166,10 +2457,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom 0.3.1",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "tera"
@@ -2238,6 +2554,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -2502,16 +2828,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
 name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2524,6 +2873,12 @@ name = "uuid"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -2561,6 +2916,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasite"
@@ -2779,12 +3143,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "synstructure",
 ]
 
 [[package]]
@@ -2802,6 +3211,49 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "synstructure",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -271,7 +271,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -359,7 +359,7 @@ version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
 dependencies = [
- "crossterm",
+ "crossterm 0.28.1",
  "strum",
  "strum_macros",
  "unicode-width 0.2.0",
@@ -433,6 +433,22 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
 
 [[package]]
 name = "crossterm"
@@ -607,6 +623,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +777,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,7 +824,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1207,6 +1247,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.8.0",
+ "chrono",
+ "crossterm 0.25.0",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "is-docker"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1536,6 +1594,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
@@ -1573,6 +1643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +1675,7 @@ dependencies = [
  "html-escape",
  "hyper",
  "indoc",
+ "inquire",
  "mime_guess",
  "minify-html",
  "minify-js 0.6.0",
@@ -1630,7 +1710,7 @@ dependencies = [
  "kqueue",
  "libc",
  "log",
- "mio",
+ "mio 1.0.3",
  "notify-types",
  "walkdir",
  "windows-sys 0.59.0",
@@ -1774,7 +1854,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2320,6 +2400,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2557,6 +2658,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,7 +2701,7 @@ dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
+ "mio 1.0.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3048,7 +3159,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3057,7 +3177,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3066,7 +3186,22 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3075,15 +3210,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3093,9 +3234,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3111,9 +3264,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3123,9 +3288,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ semver = { version = "1.0.25", features = ["serde"] }
 git2 = "0.20.0"
 tempfile = "3.17.1"
 inquire = { version = "0.7.5", features = ["chrono", "date"] }
+spinoff = "0.8.0"
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ num_cpus = "1.16.0"
 minify-js = "0.6.0"
 css-minify = "0.5.2"
 regex = "1.11.1"
+semver = { version = "1.0.25", features = ["serde"] }
+git2 = "0.20.0"
+tempfile = "3.17.1"
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ regex = "1.11.1"
 semver = { version = "1.0.25", features = ["serde"] }
 git2 = "0.20.0"
 tempfile = "3.17.1"
+inquire = { version = "0.7.5", features = ["chrono", "date"] }
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/flake.nix
+++ b/flake.nix
@@ -57,10 +57,14 @@
             cargo-edit
             cargo-nextest
             rust-analyzer
+            pkg-config # Required by git2 crate
+            openssl # Required by git2 crate
           ];
 
           # Many editors rely on this rust-src PATH variable
           RUST_SRC_PATH = "${toolchain.rustLibSrc}";
+
+          PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
         };
       });
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,11 @@ enum Commands {
         /// Site name
         name: Option<String>,
     },
+    /// Theme management
+    Theme {
+        #[command(subcommand)]
+        subcommand: cmd::ThemeCommands,
+    },
     /// Build a site for development
     Serve {
         #[arg(short = 'p', long, default_value_t = 3030, help = "Port to be used")]
@@ -110,6 +115,7 @@ pub async fn start() -> Result<()> {
 
     match &cli.command {
         Commands::Init { name } => init_site(name.as_ref()).await?,
+        Commands::Theme { subcommand } => theme_handle(subcommand).await?,
         Commands::Serve { port, drafts: _, _no_drafts, open } => check_and_serve(*port, !_no_drafts, *open).await?,
         Commands::Build { minify } => build_site(*minify).await?,
         Commands::New { kind, name, open } => {
@@ -169,6 +175,10 @@ async fn check_and_serve(port: u16, drafts: bool, open: bool) -> Result<()> {
     }
 
     cmd::serve(port, drafts, open).await
+}
+
+async fn theme_handle(subcommand: &cmd::ThemeCommands) -> Result<()> {
+    cmd::theme(subcommand).await
 }
 
 /// Creates a new asset with the given kind and name.

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -197,9 +197,10 @@ pub async fn build(minify: bool) -> Result<()> {
         let templates_dir = root_dir.clone() + "/templates";
         let content_dir = Path::new(&root_dir.clone()).join("content");
         let assets_dir = Path::new(&root_dir.clone()).join("assets");
+        let theme_dir = Path::new(&root_dir.clone()).join("theme");
 
         // Initialize Tera once
-        let tera = shared::init_tera(&templates_dir).await?;
+        let tera = shared::init_tera(&templates_dir, &theme_dir).await?;
 
         // Prepare the public build directory
         prepare_build_directory(Path::new(&root_dir)).await?;

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -2,8 +2,13 @@ mod init;
 mod new;
 mod serve;
 mod build;
+mod theme;
 
-pub use self::init::init;
-pub use self::new::new;
-pub use self::serve::serve;
-pub use self::build::build;
+pub use self::{
+    init::init,
+    new::new,
+    serve::serve,
+    build::build,
+    theme::handle as theme,
+    theme::ThemeCommands,
+};

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -353,12 +353,13 @@ pub async fn serve(port: u16, drafts: bool, open: bool) -> Result<()> {
         let templates_dir = root_dir.clone() + "/templates";
         let content_dir = Path::new(&root_dir.clone()).join("content");
         let assets_dir = Path::new(&root_dir.clone()).join("assets");
+        let theme_dir = Path::new(&root_dir.clone()).join("theme");
 
         // Async runtime handle
         let rt = Handle::current();
 
         // Initialize Tera once
-        let tera = Arc::new(RwLock::new(shared::init_tera(&templates_dir).await?));
+        let tera = Arc::new(RwLock::new(shared::init_tera(&templates_dir, &theme_dir).await?));
 
         // Create reload channel
         let (reload_tx, _) = broadcast::channel(16);

--- a/src/cmd/theme.rs
+++ b/src/cmd/theme.rs
@@ -1,0 +1,143 @@
+use eyre::{bail, Context, Result};
+
+use clap::Subcommand;
+
+use crate::{
+    fs,
+    theme::{self, ThemeManager, ThemeMetadata},
+};
+
+#[derive(Subcommand, Clone)]
+pub enum ThemeCommands {
+    /// Install a theme from a repository (github, codeberg or sourcehut)
+    Pull {
+        /// Repository shorthand (e.g. user/repo or github:user/repo)
+        repo: String,
+
+        /// Theme version (optional, defaults to the latest release)
+        version: Option<String>,
+
+        /// Pin to current major version
+        #[arg(long)]
+        pin: bool,
+    },
+    /// Update the current theme
+    Update,
+    /// Initialize theme structure (WIP)
+    Init,
+    /// Show theme information
+    Info,
+}
+
+async fn pull_theme(repo: &str, version: &Option<String>, pin: bool) -> Result<()> {
+    // Try to find a 'norgolith.toml' file in the current working directory and its parents
+    let mut current_dir = std::env::current_dir()?;
+    let found_site_root =
+        fs::find_in_previous_dirs("file", "norgolith.toml", &mut current_dir).await?;
+
+    if let Some(mut root) = found_site_root {
+        // Remove `norgolith.toml` from the root path
+        root.pop();
+        let theme_dir = root.join("theme");
+
+        let mut theme = ThemeManager {
+            repo: repo.to_string(),
+            version: semver::Version::new(0, 0, 0), // Placeholder, we will grab the version from latest release
+            pin,
+            theme_dir,
+        };
+        if let Some(version) = version {
+            theme.version =
+                semver::Version::parse(version).context("No valid semantic version provided")?;
+        }
+
+        println!("[theme] Pulling theme from '{}' ...", theme::resolve_repo_shorthand(repo).await?);
+        theme.pull().await?;
+    } else {
+        bail!("[theme] Could not pull the theme: not in a Norgolith site directory");
+    }
+
+    Ok(())
+}
+
+async fn update_theme() -> Result<()> {
+    // Try to find a 'norgolith.toml' file in the current working directory and its parents
+    let mut current_dir = std::env::current_dir()?;
+    let found_site_root =
+        fs::find_in_previous_dirs("file", "norgolith.toml", &mut current_dir).await?;
+
+    if let Some(mut root) = found_site_root {
+        // Remove `norgolith.toml` from the root path
+        root.pop();
+        let theme_dir = root.join("theme");
+
+        // Check if there is a 'metadata.toml' in the theme directory before proceeding
+        if theme_dir.join("metadata.toml").exists() {
+            // Load the current theme metadata
+            let metadata_content =
+                tokio::fs::read_to_string(theme_dir.join("metadata.toml")).await?;
+            let theme_metadata: ThemeMetadata = toml::from_str(&metadata_content)?;
+
+            let mut theme = ThemeManager {
+                repo: theme_metadata.repo.clone(),
+                version: theme_metadata.version,
+                pin: theme_metadata.pin,
+                theme_dir,
+            };
+
+            println!("[theme] Updating theme ...");
+            theme.update().await?;
+        } else {
+            bail!("[theme] Could not update the theme: there is no theme installed");
+        }
+    } else {
+        bail!("[theme] Could not update the theme: not in a Norgolith site directory");
+    }
+    Ok(())
+}
+
+async fn init_theme() -> Result<()> {
+    println!("Initializing theme structure... WIP");
+    Ok(())
+}
+
+async fn show_theme_info() -> Result<()> {
+    // Try to find a 'norgolith.toml' file in the current working directory and its parents
+    let mut current_dir = std::env::current_dir()?;
+    let found_site_root =
+        fs::find_in_previous_dirs("file", "norgolith.toml", &mut current_dir).await?;
+
+    if let Some(mut root) = found_site_root {
+        // Remove `norgolith.toml` from the root path
+        root.pop();
+        let theme_dir = root.join("theme");
+
+        // Check if there is a 'metadata.toml' in the theme directory before proceeding
+        if theme_dir.join("metadata.toml").exists() {
+            let metadata_content =
+                tokio::fs::read_to_string(theme_dir.join("metadata.toml")).await?;
+            let theme_metadata: ThemeMetadata = toml::from_str(&metadata_content)?;
+
+            println!(
+                "[theme] Current theme information:\n→ Repository: {}\n→ Version: {}\n→ Pinned: {}",
+                theme_metadata.repo,
+                theme_metadata.version,
+                if theme_metadata.pin { "yes" } else { "no" },
+            );
+        } else {
+            bail!("[theme] Could not display the theme info: there is no theme installed");
+        }
+    } else {
+        bail!("[theme] Could not display the theme info: not in a Norgolith site directory");
+    }
+    Ok(())
+}
+
+pub async fn handle(subcommand: &ThemeCommands) -> Result<()> {
+    match subcommand {
+        ThemeCommands::Pull { repo, version, pin } => pull_theme(repo, version, *pin).await,
+        ThemeCommands::Update => update_theme().await,
+        ThemeCommands::Init => init_theme().await,
+        ThemeCommands::Info => show_theme_info().await,
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod config;
 mod converter;
 mod fs;
 mod net;
+mod theme;
 mod shared;
 mod tera_functions;
 

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
-use eyre::{bail, eyre, Result};
+use eyre::{bail, eyre, Context, Result};
 use tera::Tera;
 
 use crate::converter;
@@ -184,11 +184,32 @@ pub fn get_elapsed_time(instant: Instant) -> String {
     }
 }
 
-pub async fn init_tera(templates_dir: &str) -> Result<Tera> {
+pub async fn init_tera(templates_dir: &str, theme_dir: &Path) -> Result<Tera> {
+    // Initialize Tera with the user-defined templates first
     let mut tera = match Tera::new(&(templates_dir.to_owned() + "/**/*.html")) {
         Ok(t) => t,
         Err(e) => bail!("Tera parsing error(s): {}", e),
     };
+
+    // Theme templates will override the user-defined templates by design if they are named exactly
+    // the same in both the user's templates directory and the theme templates directory
+    if tokio::fs::try_exists(theme_dir.join("templates")).await? {
+        let mut theme_templates: Vec<(String, Option<String>)> = Vec::new();
+
+        let mut entries = tokio::fs::read_dir(&theme_dir.join("templates")).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+
+            if path.is_file() && path.extension().map(|e| e == "html").unwrap_or(false) {
+                theme_templates.push((path.into_os_string().into_string().unwrap(), Some(entry.file_name().into_string().unwrap())))
+            }
+        }
+        tera.add_template_files(theme_templates)
+            .wrap_err("Failed to load theme templates")?;
+    }
+
+    // Register functions
     tera.register_function("now", crate::tera_functions::NowFunction);
+
     Ok(tera)
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -26,7 +26,6 @@ pub struct ThemeMetadata {
     pub description: String,
     pub version: String,
     pub license: String,
-    pub repository: Option<String>,
 }
 
 // .metadata.toml file contents
@@ -243,7 +242,7 @@ impl ThemeManager {
             pin: self.pin,
         };
 
-        sp.update_after_time("Writing theme metadata file ...", std::time::Duration::from_millis(200));
+        sp.update_after_time("Writing theme metadata file...", std::time::Duration::from_millis(200));
         fs::write(metadata_path, toml::to_string_pretty(&metadata)?)
             .await
             .context("Failed to write metadata file")

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -17,8 +17,21 @@ pub struct ThemeManager {
     pub theme_dir: PathBuf,
 }
 
+// theme.toml file contents
 #[derive(Serialize, Deserialize)]
 pub struct ThemeMetadata {
+    pub name: String,
+    pub author: String,
+    pub description: String,
+    pub version: String,
+    pub license: String,
+    pub repository: Option<String>,
+}
+
+// .metadata.toml file contents
+// used for update/backup/rollback mechanisms
+#[derive(Serialize, Deserialize)]
+pub struct ThemeInstalledMetadata {
     pub repo: String,
     pub version: Version,
     pub pin: bool,
@@ -97,7 +110,7 @@ async fn backup_theme_files(src: &Path, dest: &Path) -> Result<()> {
 
 async fn copy_theme_files(src: &Path, dest: &Path) -> Result<()> {
     let allowed_dirs = ["templates", "assets"];
-    let allowed_files = ["README.md", "LICENSE"];
+    let allowed_files = ["README.md", "LICENSE", "theme.toml"];
 
     // Clean existing theme directory
     if dest.exists() {
@@ -222,8 +235,8 @@ impl ThemeManager {
     }
 
     async fn write_metadata(&mut self) -> Result<()> {
-        let metadata_path = self.theme_dir.join("metadata.toml");
-        let metadata = ThemeMetadata {
+        let metadata_path = self.theme_dir.join(".metadata.toml");
+        let metadata = ThemeInstalledMetadata {
             repo: self.repo.clone(),
             version: self.version.clone(),
             pin: self.pin,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,236 @@
+use std::path::{Path, PathBuf};
+
+use eyre::{bail, eyre, Context, Result};
+use git2::{build::CheckoutBuilder, Repository};
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+use tempfile::tempdir;
+use tokio::fs;
+
+use crate::fs::copy_dir_all;
+
+#[derive(Clone, Debug)]
+pub struct ThemeManager {
+    pub repo: String,
+    pub version: Version,
+    pub pin: bool,
+    pub theme_dir: PathBuf,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ThemeMetadata {
+    pub repo: String,
+    pub version: Version,
+    pub pin: bool,
+}
+
+pub async fn resolve_repo_shorthand(repo: &str) -> Result<String> {
+    if let Some((service, rest)) = repo.split_once(':') {
+        match service.to_lowercase().as_str() {
+            "gh" | "github" => Ok(format!("https://github.com/{}", rest)),
+            "srht" | "sourcehut" => Ok(format!("https://git.sr.ht/~{}", rest)),
+            "berg" | "codeberg" => Ok(format!("https://codeberg.org/{}", rest)),
+            _ => bail!("Unknown repository service: {}", service),
+        }
+    } else {
+        // Assume GitHub by default if 'author/repo' has been passed instead of
+        // trying to use something like gh:author/repo
+        Ok(format!("https://github.com/{}", repo))
+    }
+}
+
+async fn get_version(repo: &Repository, requirement: Option<String>) -> Result<Version> {
+    let mut versions = repo
+        .tag_names(None)?
+        .iter()
+        .flatten()
+        .filter_map(|t| Version::parse(t).ok())
+        .collect::<Vec<_>>();
+
+    if let Some(req) = requirement {
+        let version_req = VersionReq::parse(&req)?;
+        versions.retain(|v| version_req.matches(v));
+    }
+
+    versions.sort();
+    versions
+        .last()
+        .cloned()
+        .ok_or_else(|| eyre!("No matching versions found"))
+}
+
+async fn checkout_version(repo: &Repository, version: &Version) -> Result<()> {
+    let tag_name = version.to_string();
+    let (object, reference) = repo.revparse_ext(&tag_name)?;
+
+    repo.checkout_tree(&object, Some(CheckoutBuilder::new().force()))?;
+
+    if let Some(reference) = reference {
+        repo.set_head(
+            reference
+                .name()
+                .ok_or_else(|| eyre!("Invalid reference name"))?,
+        )?;
+    }
+
+    Ok(())
+}
+
+async fn backup_theme_files(src: &Path, dest: &Path) -> Result<()> {
+    // If the theme directory is empty then early return
+    if src.read_dir()?.next().is_none() {
+        return Ok(());
+    }
+
+    // TODO: make backup directory capable of holding more states
+    // than just the last one before pulling/updating a theme
+    if dest.exists() {
+        tokio::fs::remove_dir_all(dest).await?;
+    }
+    tokio::fs::create_dir_all(dest).await?;
+
+    println!("[theme] Backing up theme files ...");
+    copy_dir_all(src, dest).await?;
+
+    Ok(())
+}
+
+async fn copy_theme_files(src: &Path, dest: &Path) -> Result<()> {
+    let allowed_dirs = ["templates", "assets"];
+    let allowed_files = ["README.md", "LICENSE"];
+
+    // Clean existing theme directory
+    if dest.exists() {
+        fs::remove_dir_all(dest).await?;
+    }
+    fs::create_dir_all(dest).await?;
+
+    println!("[theme] Copying theme files ...");
+    let mut entries = fs::read_dir(src).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let file_name = entry.file_name();
+        let file_name_str = file_name.clone().into_string().unwrap();
+
+        if allowed_dirs.contains(&file_name_str.as_ref()) {
+            copy_dir_all(entry.path(), dest.join(file_name)).await?;
+        } else if allowed_files.contains(&file_name_str.as_ref()) {
+            fs::copy(entry.path(), dest.join(file_name)).await?;
+        }
+    }
+
+    Ok(())
+}
+
+impl ThemeManager {
+    pub async fn pull(&mut self) -> Result<Self> {
+        let repo_url = resolve_repo_shorthand(&self.repo).await?;
+        let temp_dir = tempdir().context("Failed to create temporary directory")?;
+
+        // Clone repository
+        let repo = Repository::clone(&repo_url, temp_dir.path())
+            .context("Failed to clone theme repository")?;
+
+        // Get the version tag
+        let version = if self.version.to_string() == "0.0.0" {
+            get_version(&repo, None)
+                .await
+                .context("No valid semantic versions found in repository")?
+        } else {
+            get_version(&repo, Some(self.version.to_string()))
+                .await
+                .context(format!("Version {} not found in repository", self.version))?
+        };
+        checkout_version(&repo, &version).await?;
+
+        // Backup existing theme files before installing a new one
+        let backup_dir = self.theme_dir.parent().unwrap().join(".theme_backup");
+        backup_theme_files(&self.theme_dir, &backup_dir)
+            .await
+            .context("Failed to backup theme files")?;
+
+        // Copy theme files
+        copy_theme_files(temp_dir.path(), &self.theme_dir)
+            .await
+            .context("Failed to copy theme files")?;
+
+        // Write metadata
+        self.version = version;
+        self.write_metadata()
+            .await
+            .context("Failed to write theme metadata")?;
+
+        Ok(self.clone())
+    }
+
+    pub async fn update(&mut self) -> Result<Self> {
+        // 1. Check remote tags respecting semver and pin status
+        // 2. Diff existing theme files
+        // 3. Apply updates if needed
+        let repo_url = resolve_repo_shorthand(&self.repo).await?;
+        let temp_dir = tempdir().context("Failed to create temporary directory")?;
+
+        // Clone repository
+        let repo = Repository::clone(&repo_url, temp_dir.path())
+            .context("Failed to clone theme repository")?;
+
+        // Calculate version requirement
+        let version_req = if self.pin {
+            format!("^{}.0.0", self.version.major)
+        } else {
+            "*".to_string()
+        };
+
+        // Get updatable version
+        let latest_version = get_version(&repo, Some(version_req))
+            .await
+            .context("No valid update versions found")?;
+
+        if latest_version > self.version {
+            // Checkout new version
+            checkout_version(&repo, &latest_version)
+                .await
+                .context("Failed to checkout new theme version")?;
+
+            // Backup current theme files
+            let backup_dir = self.theme_dir.parent().unwrap().join(".theme_backup");
+            backup_theme_files(&self.theme_dir, &backup_dir)
+                .await
+                .context("Failed to backup theme files")?;
+
+            // Copy new theme version files
+            copy_theme_files(temp_dir.path(), &self.theme_dir)
+                .await
+                .context("Failed to update theme files")?;
+
+            // Update metadata
+            self.version = latest_version;
+            self.write_metadata()
+                .await
+                .context("Failed to update theme metadata")?;
+        } else {
+            println!(
+                "[theme] The theme version is up-to-date{}",
+                if self.pin {
+                    format!(" (pinned to: {})", self.version)
+                } else {
+                    String::from("")
+                }
+            );
+        }
+
+        Ok(self.clone())
+    }
+
+    async fn write_metadata(&mut self) -> Result<()> {
+        let metadata_path = self.theme_dir.join("metadata.toml");
+        let metadata = ThemeMetadata {
+            repo: self.repo.clone(),
+            version: self.version.clone(),
+            pin: self.pin,
+        };
+
+        fs::write(metadata_path, toml::to_string_pretty(&metadata)?)
+            .await
+            .context("Failed to write metadata file")
+    }
+}


### PR DESCRIPTION
- Add `lith theme` subcommands for theme lifecycle management
  - Support `install`/`update`/`info` operations with semantic versioning
  - Add repository shorthand resolution (`gh:|github:`/`berg:|codeberg:` prefixes)
- Integrate theme templates into rendering pipeline
  - Load theme templates from theme/templates with lower priority than user templates
  - Maintain template override hierarchy for user customization
- Add `ThemeManager` struct for handling theme operations
  - Track `repository`, `version`, and `pin` status in metadata
  - Prepare foundation for git-based theme fetching
- Update build/serve commands to include theme assets
  - Ensure theme resources are available during site generation
  - Add `theme` directory to Tera initialization
- Add `semver` dependency for version constraint management
- Implement theme metadata serialization/deserialization

Resolves #51