### PR TITLE
ref!: overhaul the commands codebase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,6 +1702,7 @@ dependencies = [
  "tempfile",
  "tera",
  "tokio",
+ "tokio-stream",
  "tokio-tungstenite",
  "toml",
  "walkdir",
@@ -2740,6 +2741,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.96",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ git2 = "0.20.0"
 tempfile = "3.17.1"
 inquire = { version = "0.7.5", features = ["chrono", "date"] }
 spinoff = "0.8.0"
+tokio-stream = { version = "0.1.17", features = ["sync", "net"] }
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,7 +80,7 @@ enum Commands {
         open: bool,
     },
     /// Create a new asset in the site and optionally open it using your preferred system editor.
-    /// e.g. 'new -k content post1.norg' -> 'content/post1.norg'
+    /// e.g. 'new -k norg post1.norg' -> 'content/post1.norg'
     New {
         #[arg(
             short = 'o',
@@ -93,10 +93,10 @@ enum Commands {
         #[arg(
             short = 'k',
             long,
-            default_value = "content",
+            default_value = "norg",
             help = "type of asset",
             value_parser = [
-                PossibleValue::new("content").help("New norg file"),
+                PossibleValue::new("norg").help("New norg file"),
                 PossibleValue::new("css").help("New CSS stylesheet"),
                 PossibleValue::new("js").help("New JS script")
             ]
@@ -232,7 +232,7 @@ async fn new_asset(kind: Option<&String>, name: Option<&String>, open: bool) -> 
     if ![
         String::from("js"),
         String::from("css"),
-        String::from("content"),
+        String::from("norg"),
     ]
     .contains(&asset_type)
     {

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -1,37 +1,88 @@
-use std::path::Path;
-use std::sync::Arc;
+use std::{path::{Path, PathBuf}, sync::Arc};
 
-use eyre::{bail, Result};
+use eyre::{bail, Result, WrapErr};
 use futures_util::{self, StreamExt};
 use tera::{Context, Tera};
 use tokio::sync::Mutex;
-use walkdir::WalkDir;
+use walkdir::{DirEntry, WalkDir};
 
-use crate::{
-    config, fs,
-    schema::{format_errors, validate_metadata, ContentSchema},
-    shared,
-};
+use crate::{config, fs, schema::ContentSchema, shared};
 
+/// Represents the directory structure of a Norgolith site.
+///
+/// This struct defines paths to key directories used during the build process,
+/// including build artifacts, public output, content sources, and theme resources.
+struct SitePaths {
+    build: PathBuf,
+    public: PathBuf,
+    content: PathBuf,
+    assets: PathBuf,
+    theme_assets: PathBuf,
+    templates: PathBuf,
+}
+
+impl SitePaths {
+    /// Creates a new `SitePaths` instance based on the provided root directory.
+    ///
+    /// Initializes paths for build artifacts, public output, content sources,
+    /// assets, theme assets, and templates by combining with root subdirectories.
+    ///
+    /// # Arguments
+    /// * `root` - Root directory containing norgolith.toml config file
+    fn new(root: PathBuf) -> Self {
+        Self {
+            build: root.join(".build"),
+            public: root.join("public"),
+            content: root.join("content"),
+            assets: root.join("assets"),
+            theme_assets: root.join("theme/assets"),
+            templates: root.join("templates"),
+        }
+    }
+}
+
+/// Prepares the build directory by cleaning existing artifacts
+///
+/// # Arguments
+/// * `root_path` - Root directory of the site
 async fn prepare_build_directory(root_path: &Path) -> Result<()> {
     let public_dir = root_path.join("public");
     if public_dir.exists() {
-        tokio::fs::remove_dir_all(&public_dir).await?;
+        tokio::fs::remove_dir_all(&public_dir)
+            .await
+            .wrap_err(format!(
+                "Failed to remove existing public directory: {}",
+                public_dir.display()
+            ))?;
     }
 
-    Ok(tokio::fs::create_dir_all(public_dir).await?)
+    tokio::fs::create_dir_all(&public_dir)
+        .await
+        .wrap_err(format!(
+            "Failed to create public directory: {}",
+            public_dir.display()
+        ))?;
+
+    Ok(())
 }
 
+/// Generates the final public build from intermediate build artifacts
+///
+/// Processes HTML files through templates and handles minification.
+/// Performs concurrent processing of build artifacts with validation.
+///
+/// # Arguments
+/// * `tera` - Template engine instance
+/// * `paths` - Site directory paths
+/// * `site_config` - Site configuration
+/// * `minify` - Enable minification of output
 async fn generate_public_build(
     tera: &Tera,
-    root_path: &Path,
+    paths: &SitePaths,
     site_config: config::SiteConfig,
     minify: bool,
 ) -> Result<()> {
-    let build_dir = root_path.join(".build");
-    let public_dir = root_path.join("public");
-    let content_dir = root_path.join("content");
-    let entries = WalkDir::new(&build_dir).into_iter().filter_map(|e| e.ok());
+    let entries = WalkDir::new(&paths.build).into_iter().filter_map(|e| e.ok());
 
     // Shared error state for concurrent validation
     let validation_errors = Arc::new(Mutex::new(Vec::new()));
@@ -39,146 +90,344 @@ async fn generate_public_build(
     // Parallel processing
     futures_util::stream::iter(entries)
         .for_each_concurrent(num_cpus::get(), |entry| {
-            let build_dir = build_dir.clone();
-            let public_dir = public_dir.clone();
-            let content_dir = content_dir.clone();
             let site_config = site_config.clone();
             let validation_errors = Arc::clone(&validation_errors);
 
             async move {
-                let path = entry.path();
-                if path.is_file() && path.extension().map(|e| e == "html").unwrap_or(false) {
-                    let rel_path = path.strip_prefix(&build_dir).unwrap();
-                    let stem = rel_path.file_stem().unwrap().to_str().unwrap();
-
-                    // Determine output path
-                    let public_path = if stem == "index" {
-                        public_dir.join(rel_path)
-                    } else {
-                        public_dir
-                            .join(rel_path.parent().unwrap())
-                            .join(stem)
-                            .join("index.html")
-                    };
-
-                    // Read content and metadata
-                    let html = tokio::fs::read_to_string(path).await.unwrap();
-                    let meta_path = path.with_extension("meta.toml");
-
-                    // Handle metadata loading with proper error fallback
-                    let metadata: toml::Value =
-                        match tokio::fs::read_to_string(meta_path.clone()).await {
-                            Ok(content) => toml::from_str(&content).unwrap_or_else(|e| {
-                                // Fallback to empty table on parse errors
-                                eprintln!("[build] Failed to parse metadata: {}", e);
-                                toml::Value::Table(toml::map::Map::new())
-                            }),
-                            Err(e) => {
-                                // Fallback to empty table if file not found
-                                eprintln!("[build] Metadata file not found: {}", e);
-                                toml::Value::Table(toml::map::Map::new())
-                            }
-                        };
-
-                    // Metadata schema validation
-                    if let Some(schema) = &site_config.content_schema {
-                        // Get relative content path
-                        let content_path = path
-                            .strip_prefix(&build_dir)
-                            .unwrap()
-                            .with_extension("")
-                            .to_str()
-                            .unwrap()
-                            .replace('\\', "/");
-
-                        // Resolve schema hierarchy
-                        let schema_nodes = schema.resolve_path(&content_path);
-                        let merged_schema = ContentSchema::merge_hierarchy(&schema_nodes);
-
-                        // Convert metadata to hashmap for validation
-                        let metadata_map = metadata
-                            .as_table()
-                            .unwrap()
-                            .iter()
-                            .map(|(k, v)| (k.clone(), v.clone()))
-                            .collect();
-
-                        // Perform validation
-                        let errors = validate_metadata(&metadata_map, &merged_schema);
-
-                        // Collect errors
-                        if !errors.is_empty() {
-                            let norg_path = content_dir
-                                .join(content_path.clone())
-                                .strip_prefix(root_path)
-                                .unwrap()
-                                .with_extension("norg");
-                            let error_output = format!(
-                                "[build] {}",
-                                format_errors(&norg_path, &content_path, &errors, false)
-                            );
-
-                            validation_errors.lock().await.push(error_output);
-                        }
-                    }
-
-                    // Do not try to build draft content for production builds
-                    if toml::Value::as_bool(
-                        metadata.get("draft").unwrap_or(&toml::Value::from(false)),
-                    )
-                    .expect("draft metadata field should be a boolean")
-                    {
-                        return;
-                    }
-
-                    // Get the layout (template) to render the content, fallback to default if the metadata field was not found.
-                    let layout = metadata
-                        .get("layout")
-                        .unwrap_or(&toml::Value::from("default"))
-                        .as_str()
-                        .unwrap()
-                        .to_owned();
-
-                    // Build template context
-                    let mut context = Context::new();
-                    context.insert("content", &html);
-                    context.insert("config", &site_config);
-                    context.insert("metadata", &metadata);
-
-                    // Get the template to use for rendering
-                    let mut rendered = tera.render(&(layout + ".html"), &context).unwrap();
-
-                    if minify {
-                        let minify_config = minify_html::Cfg {
-                            minify_js: true,
-                            minify_css: true,
-                            ..minify_html::Cfg::default()
-                        };
-                        rendered = String::from_utf8(minify_html::minify(
-                            rendered.as_bytes(),
-                            &minify_config,
-                        ))
-                        .unwrap();
-                    }
-
-                    tokio::fs::create_dir_all(public_path.parent().unwrap())
-                        .await
-                        .unwrap();
-                    tokio::fs::write(public_path, rendered).await.unwrap();
+                if let Err(e) = process_build_entry(entry, tera, paths, &site_config, minify, &validation_errors).await {
+                    eprintln!("Error processing entry: {:?}", e);
                 }
             }
         })
-        .await;
+    .await;
 
-    // Check collected errors
     let errors = validation_errors.lock().await;
     if !errors.is_empty() {
-        bail!(errors.join("\n"));
+        bail!(errors.concat());
     }
 
     Ok(())
 }
 
+/// Processes a single build entry (HTML file with metadata)
+///
+/// Handles template rendering, metadata validation, and output path determination.
+/// Skips draft content and applies minification when enabled.
+async fn process_build_entry(
+    entry: DirEntry,
+    tera: &Tera,
+    paths: &SitePaths,
+    site_config: &config::SiteConfig,
+    minify: bool,
+    validation_errors: &Arc<Mutex<Vec<String>>>,
+) -> Result<()> {
+    let path = entry.path();
+
+    if path.is_file() && path.extension().map(|e| e == "html").unwrap_or(false) {
+        let rel_path = path.strip_prefix(&paths.build).wrap_err("Failed to strip prefix")?;
+        let stem = rel_path.file_stem().and_then(|s| s.to_str()).ok_or_else(|| eyre::eyre!("No file stem"))?;
+
+        // Determine output path
+        let public_path = determine_public_path(&paths.public, rel_path, stem);
+
+        // Read content and metadata
+        let html = tokio::fs::read_to_string(path)
+            .await
+            .wrap_err_with(|| format!("Failed to read HTML file: {:?}", path))?;
+        let meta_path = path.with_extension("meta.toml");
+
+        // Handle metadata loading with proper error fallback
+        let metadata = shared::load_metadata(meta_path).await;
+
+        // Metadata schema validation
+        if let Some(schema) = &site_config.content_schema {
+            validate_metadata(
+                path,
+                &paths.build,
+                &paths.content,
+                schema,
+                validation_errors,
+            ).await?;
+        }
+
+        // Do not try to build draft content for production builds
+        if toml::Value::as_bool(
+            metadata.get("draft").unwrap_or(&toml::Value::from(false)),
+        )
+        .expect("draft metadata field should be a boolean")
+        {
+            return Ok(());
+        }
+
+        // Get the layout (template) to render the content, fallback to default if not found.
+        let layout = metadata
+            .get("layout")
+            .unwrap_or(&toml::Value::from("default"))
+            .as_str()
+            .unwrap()
+            .to_owned();
+
+        // Build template context
+        let mut context = Context::new();
+        context.insert("content", &html);
+        context.insert("config", &site_config);
+        context.insert("metadata", &metadata);
+
+        // Render template
+        let rendered = tera.render(&(layout + ".html"), &context).unwrap();
+
+        let rendered = if minify {
+            minify_html_content(rendered)?
+        } else {
+            rendered
+        };
+
+        // Write rendered output to public path
+        write_public_file(&public_path, rendered).await?;
+    }
+    Ok(())
+}
+
+/// Validates content metadata against a schema
+///
+/// Collects validation errors for aggregated reporting
+async fn validate_metadata(
+    path: &Path,
+    build_dir: &Path,
+    content_dir: &Path,
+    schema: &ContentSchema,
+    validation_errors: &Arc<Mutex<Vec<String>>>,
+) -> Result<()> {
+    // Get relative content path
+    let content_path = path
+        .strip_prefix(build_dir)
+        .wrap_err("Failed to strip build dir prefix for content path")?
+        .with_extension("")
+        .to_str()
+        .ok_or_else(|| eyre::eyre!("Failed to convert content path to string"))?
+        .replace('\\', "/"); // Normalize path separators
+
+    let norg_content_path = content_dir.join(content_path).with_extension("norg");
+
+    // Perform validation
+    let errors = shared::validate_content_metadata(&norg_content_path, build_dir, content_dir, schema, false)
+        .await?;
+
+    // Collect errors
+    if !errors.is_empty() {
+        validation_errors.lock().await.push(errors);
+    }
+    Ok(())
+}
+
+/// Determines the final public path for an HTML file based on its name and location.
+///
+/// This function creates SEO-friendly URLs by nesting non-index files in directories.
+/// For example, a file named `about.html` will be placed in `about/index.html`.
+/// Files named `index.html` are placed directly in their parent directory.
+///
+/// # Arguments
+/// * `public_dir` - The root public directory where the final build is stored.
+/// * `rel_path` - The relative path of the file within the build directory.
+/// * `stem` - The file stem (name without extension) of the HTML file.
+///
+/// # Returns
+/// * `PathBuf` - The final public path for the HTML file.
+fn determine_public_path(public_dir: &Path, rel_path: &Path, stem: &str) -> PathBuf {
+    if stem == "index" {
+        public_dir.join(rel_path)
+    } else {
+        public_dir
+            .join(rel_path.parent().unwrap_or(Path::new(""))) // Handle root path parent gracefully
+            .join(stem)
+            .join("index.html")
+    }
+}
+
+/// Writes rendered content to the public directory, ensuring parent directories exist.
+///
+/// This function creates any necessary parent directories before writing the file
+/// to the specified public path. It is used to save rendered HTML content and
+/// other assets to their final locations.
+///
+/// # Arguments
+/// * `public_path` - The path where the file should be written in the public directory.
+/// * `rendered` - The content to write to the file.
+///
+/// # Returns
+/// * `Result<()>` - `Ok(())` if the file is written successfully, otherwise an error.
+async fn write_public_file(public_path: &Path, rendered: String) -> Result<()> {
+    tokio::fs::create_dir_all(public_path.parent().unwrap())
+        .await
+        .wrap_err(format!("Failed to create parent directory for: {}", public_path.display()))?;
+    tokio::fs::write(public_path, rendered)
+        .await
+        .wrap_err(format!("Failed to write to public path: {}", public_path.display()))?;
+    Ok(())
+}
+
+/// Determines whether an asset should be minified based on its name and extension.
+///
+/// This function checks if the asset is a JavaScript or CSS file and does not already
+/// have "min" in its name. Assets with "min" in their name or non-JS/CSS extensions
+/// are skipped for minification.
+///
+/// # Arguments
+/// * `src` - The path to the asset file.
+///
+/// # Returns
+/// * `bool` - `true` if the asset should be minified, `false` otherwise.
+fn should_minify_asset(src: &Path) -> bool {
+    let file_stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or_default();
+    let file_ext = src.extension().and_then(|s| s.to_str()).unwrap_or_default();
+    file_stem != "min" && (file_ext == "js" || file_ext == "css")
+}
+
+/// Minifies HTML content using optimized settings for production builds.
+///
+/// This function applies minification to HTML content, including optional minification
+/// of embedded JavaScript and CSS. It uses the `minify-html` crate for efficient
+/// minification.
+///
+/// # Arguments
+/// * `rendered` - The HTML content to minify.
+///
+/// # Returns
+/// * `Result<String>` - The minified HTML content if successful, otherwise an error.
+fn minify_html_content(rendered: String) -> Result<String> {
+    let minify_config = minify_html::Cfg {
+        minify_js: true,
+        minify_css: true,
+        ..minify_html::Cfg::default()
+    };
+    String::from_utf8(minify_html::minify(rendered.as_bytes(), &minify_config))
+        .map_err(|e| eyre::eyre!("HTML minification failed: {}", e))
+}
+
+/// Minifies a JavaScript asset using the `minify-js` crate.
+///
+/// This function reads a JavaScript file, minifies its content, and writes the
+/// minified output to the destination path. It is used for production builds
+/// to reduce file size and improve performance.
+///
+/// # Arguments
+/// * `src_path` - The path to the source JavaScript file.
+/// * `dest_path` - The path where the minified JavaScript should be saved.
+///
+/// # Returns
+/// * `Result<()>` - `Ok(())` if minification and writing succeed, otherwise an error.
+async fn minify_js_asset(src_path: &Path, dest_path: &Path) -> Result<()> {
+    let content = tokio::fs::read(src_path).await?;
+    let mut minified = Vec::new();
+    let session = minify_js::Session::new();
+    minify_js::minify(
+        &session,
+        minify_js::TopLevelMode::Global,
+        &content,
+        &mut minified,
+    )
+    .map_err(|e| eyre::eyre!("JS minification failed for {}: {}", src_path.display(), e))?;
+    tokio::fs::write(dest_path, minified)
+        .await
+        .wrap_err_with(|| format!("Failed to write minified JS to {}", dest_path.display()))?;
+    Ok(())
+}
+
+/// Minifies a CSS asset using the `css-minify` crate.
+///
+/// This function reads a CSS file, applies level 2 optimizations, and writes the
+/// minified output to the destination path. It is used for production builds
+/// to reduce file size and improve performance.
+///
+/// # Arguments
+/// * `src_path` - The path to the source CSS file.
+/// * `dest_path` - The path where the minified CSS should be saved.
+///
+/// # Returns
+/// * `Result<()>` - `Ok(())` if minification and writing succeed, otherwise an error.
+async fn minify_css_asset(src_path: &Path, dest_path: &Path) -> Result<()> {
+    let content = tokio::fs::read_to_string(src_path).await?;
+    // See https://docs.rs/css-minify/0.5.2/css_minify/optimizations/enum.Level.html#variants
+    let minified = css_minify::optimizations::Minifier::default()
+        .minify(&content, css_minify::optimizations::Level::Two)
+        .map_err(|e| eyre::eyre!("CSS minification failed for {}: {}", src_path.display(), e))?;
+    tokio::fs::write(dest_path, minified.into_bytes())
+        .await
+        .wrap_err_with(|| format!("Failed to write minified CSS to {}", dest_path.display()))?;
+    Ok(())
+}
+
+/// Copies a binary asset without modification.
+///
+/// This function reads a binary file (e.g., images, fonts) and writes it to the
+/// destination path. It is used for assets that do not require minification.
+///
+/// # Arguments
+/// * `src_path` - The path to the source binary file.
+/// * `dest_path` - The path where the binary file should be saved.
+///
+/// # Returns
+/// * `Result<()>` - `Ok(())` if the file is copied successfully, otherwise an error.
+async fn copy_binary_asset(src_path: &Path, dest_path: &Path) -> Result<()> {
+    let content = tokio::fs::read(src_path).await?;
+    tokio::fs::write(dest_path, content)
+        .await
+        .wrap_err_with(|| {
+            format!(
+                "Failed to copy asset from {} to {}",
+                src_path.display(),
+                dest_path.display()
+            )
+        })?;
+    Ok(())
+}
+
+/// Copies an asset file with optional minification based on its type.
+///
+/// This function handles the copying of assets, applying minification to JavaScript
+/// and CSS files when enabled. Other file types are copied without modification.
+///
+/// # Arguments
+/// * `src_path` - The path to the source asset file.
+/// * `dest_path` - The path where the asset should be saved.
+/// * `minify` - Whether to minify supported assets during the copy process.
+///
+/// # Returns
+/// * `Result<()>` - `Ok(())` if the file is processed successfully, otherwise an error.
+async fn copy_asset_file(src_path: &Path, dest_path: &Path, minify: bool) -> Result<()> {
+    if minify {
+        if should_minify_asset(src_path) {
+            let file_ext = src_path.extension().unwrap().to_str().unwrap();
+
+            match file_ext {
+                "js" => minify_js_asset(src_path, dest_path).await?,
+                "css" => minify_css_asset(src_path, dest_path).await?,
+                _ => copy_binary_asset(src_path, dest_path).await?,
+            }
+        } else {
+            // Copy file as binary, this lets us write images and some other formats as well instead of only text files
+            copy_binary_asset(src_path, dest_path).await?;
+        }
+    } else {
+        // Copy file as binary, this lets us write images and some other formats as well instead of only text files
+        copy_binary_asset(src_path, dest_path).await?;
+    }
+    Ok(())
+}
+
+/// Copies all site and theme assets to the public directory.
+///
+/// Theme assets are copied first, followed by site assets, allowing site assets to override
+/// theme assets with the same name. Supports optional minification of JS and CSS files.
+///
+/// # Arguments
+/// * `site_assets_dir` - Path to the site's assets directory.
+/// * `theme_assets_dir` - Path to the theme's assets directory.
+/// * `root_path` - Root directory of the site.
+/// * `minify` - Whether to minify supported assets during copying.
+///
+/// # Returns
+/// * `Result<()>` - `Ok(())` if all assets are copied successfully, otherwise an error.
 async fn copy_all_assets(
     site_assets_dir: &Path,
     theme_assets_dir: &Path,
@@ -196,10 +445,36 @@ async fn copy_all_assets(
     Ok(())
 }
 
+/// Recursively copies assets from a source directory to the public assets directory.
+///
+/// This function processes all files and subdirectories in the source directory,
+/// copying them to the corresponding location in the public assets directory.
+/// It handles both files and directories, ensuring the directory structure is preserved.
+///
+/// # Arguments
+/// * `assets_dir` - The source directory containing the assets to copy.
+/// * `root_path` - The root directory of the site, used to determine the public output path.
+/// * `minify` - Whether to minify supported assets (e.g., JS and CSS) during the copy process.
+///
+/// # Returns
+/// * `Result<()>` - `Ok(())` if all assets are copied successfully, otherwise an error.
 async fn copy_assets(assets_dir: &Path, root_path: &Path, minify: bool) -> Result<()> {
     let public_dir = root_path.join("public");
     let public_assets = public_dir.join("assets");
 
+    /// Recursively processes a directory entry and copies it to the destination.
+    ///
+    /// This helper function is used by `copy_assets` to handle individual files and directories.
+    /// For directories, it recursively processes their contents. For files, it copies them
+    /// to the destination with optional minification.
+    ///
+    /// # Arguments
+    /// * `src_path` - The source path of the file or directory to process.
+    /// * `dest_path` - The destination path where the file or directory should be copied.
+    /// * `minify` - Whether to minify supported assets during the copy process.
+    ///
+    /// # Returns
+    /// * `Result<()>` - `Ok(())` if the entry is processed successfully, otherwise an error.
     async fn process_entry(src_path: &Path, dest_path: &Path, minify: bool) -> Result<()> {
         if src_path.is_dir() {
             // Create destination directory
@@ -214,43 +489,8 @@ async fn copy_assets(assets_dir: &Path, root_path: &Path, minify: bool) -> Resul
 
                 Box::pin(process_entry(&entry_path, &new_dest, minify)).await?;
             }
-        } else if minify {
-            // With file_stem we avoid trying to minify content that is already minified, e.g. bundled css frameworks
-            let file_stem = Path::new(src_path.file_stem().unwrap())
-                .extension()
-                .unwrap_or_default()
-                .to_str()
-                .unwrap();
-            let file_ext = src_path.extension().unwrap().to_str().unwrap();
-
-            if file_stem != "min" && file_ext == "js" {
-                let content = tokio::fs::read(src_path).await?;
-                let mut minified = Vec::new();
-                let session = minify_js::Session::new();
-                minify_js::minify(
-                    &session,
-                    minify_js::TopLevelMode::Global,
-                    &content,
-                    &mut minified,
-                )
-                .unwrap();
-                tokio::fs::write(dest_path, content).await?;
-            } else if file_stem != "min" && file_ext == "css" {
-                let content = tokio::fs::read_to_string(src_path).await?;
-                // See https://docs.rs/css-minify/0.5.2/css_minify/optimizations/enum.Level.html#variants
-                let minified = css_minify::optimizations::Minifier::default()
-                    .minify(&content, css_minify::optimizations::Level::Two)
-                    .unwrap();
-                tokio::fs::write(dest_path, minified).await?;
-            } else {
-                // Copy file as binary, this lets us write images and some other formats as well instead of only text files
-                let content = tokio::fs::read(&src_path).await?;
-                tokio::fs::write(&dest_path, content).await?;
-            }
         } else {
-            // Copy file as binary, this lets us write images and some other formats as well instead of only text files
-            let content = tokio::fs::read(&src_path).await?;
-            tokio::fs::write(&dest_path, content).await?;
+            copy_asset_file(src_path, dest_path, minify).await?;
         }
         Ok(())
     }
@@ -260,49 +500,50 @@ async fn copy_assets(assets_dir: &Path, root_path: &Path, minify: bool) -> Resul
     Ok(())
 }
 
+/// Main build entry point
+///
+/// Orchestrates the complete build process:
+/// 1. Load configuration
+/// 2. Prepare directories
+/// 3. Convert content
+/// 4. Generate public build
+/// 5. Copy assets
+///
+/// # Arguments
+/// * `minify` - Enable minification of HTML/CSS/JS outputs
 pub async fn build(minify: bool) -> Result<()> {
-    // Try to find a 'norgolith.toml' file in the current working directory and its parents
-    let mut current_dir = std::env::current_dir()?;
-    let found_site_root =
-        fs::find_in_previous_dirs("file", "norgolith.toml", &mut current_dir).await?;
-
-    if let Some(mut root) = found_site_root {
+    let root = fs::find_config_file().await?;
+    if let Some(root) = root {
         let build_start = std::time::Instant::now();
 
         // Load site configuration, root already contains the norgolith.toml path
         let config_content = tokio::fs::read_to_string(&root).await?;
         let site_config: config::SiteConfig = toml::from_str(&config_content)?;
 
-        // Remove `norgolith.toml` from the root path
-        root.pop();
-        let root_dir = root.into_os_string().into_string().unwrap();
+        let root_dir = root.parent().unwrap().to_path_buf();
 
         // Tera wants a `dir: &str` parameter for some reason instead of asking for a `&Path` or `&PathBuf`...
-        let templates_dir = root_dir.clone() + "/templates";
-        let content_dir = Path::new(&root_dir.clone()).join("content");
-        let assets_dir = Path::new(&root_dir.clone()).join("assets");
-        let theme_dir = Path::new(&root_dir.clone()).join("theme");
-        let theme_assets_dir = theme_dir.join("assets");
+        let paths = SitePaths::new(root_dir.clone());
 
         // Initialize Tera once
-        let tera = shared::init_tera(&templates_dir, &theme_dir).await?;
+        let tera = shared::init_tera(paths.templates.to_str().unwrap(), paths.theme_assets.parent().unwrap()).await?;
 
         // Prepare the public build directory
         prepare_build_directory(Path::new(&root_dir)).await?;
 
         // Convert the norg documents to html
-        shared::convert_content(&content_dir, false, &site_config.root_url).await?;
+        shared::convert_content(&paths.content, false, &site_config.root_url).await?;
 
         // Clean up orphaned files before building the site
-        shared::cleanup_orphaned_build_files(&content_dir).await?;
+        shared::cleanup_orphaned_build_files(&paths.content).await?;
 
         // Generate public HTML build
-        generate_public_build(&tera, Path::new(&root_dir.clone()), site_config, minify).await?;
+        generate_public_build(&tera, &paths, site_config, minify).await?;
 
         // Copy site assets
         copy_all_assets(
-            &assets_dir,
-            &theme_assets_dir,
+            &paths.assets,
+            &paths.theme_assets,
             Path::new(&root_dir.clone()),
             minify,
         )

--- a/src/cmd/serve.rs
+++ b/src/cmd/serve.rs
@@ -4,14 +4,14 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use eyre::{bail, eyre, Result};
-use futures_util::{SinkExt, StreamExt};
+use futures_util::{SinkExt, Stream, StreamExt};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{
     header::{HeaderValue, CONTENT_TYPE},
     Body, Request, Response, Server, StatusCode,
 };
-use notify::RecursiveMode;
-use notify_debouncer_full::{new_debouncer, DebounceEventResult};
+use notify::{RecommendedWatcher, RecursiveMode};
+use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, RecommendedCache};
 use tera::{Context, Tera};
 use tokio::sync::broadcast;
 use tokio::{
@@ -19,6 +19,7 @@ use tokio::{
     runtime::Handle,
     sync::RwLock,
 };
+use tokio_stream::wrappers::ReceiverStream;
 use tokio_tungstenite::accept_async;
 
 use crate::{
@@ -27,155 +28,702 @@ use crate::{
     shared,
 };
 
-// Global state for reloading
-struct ServerState {
-    reload_tx: broadcast::Sender<()>,
-    tera: Arc<RwLock<Tera>>,
-    config: config::SiteConfig,
-    content_dir: PathBuf,
-    assets_dir: PathBuf,
-    theme_assets_dir: PathBuf,
+/// Represents the directory structure of a Norgolith site.
+///
+/// This struct defines the paths to key directories in a Norgolith site, including
+/// content, assets, templates, and theme-specific assets and templates. It is used
+/// to organize and manage the file structure of the site.
+struct SitePaths {
+    content: PathBuf,
+    assets: PathBuf,
+    templates: PathBuf,
+    theme_assets: PathBuf,
+    theme_templates: PathBuf,
 }
 
-// https//github.com/livereload/livereload-js dist/livereload.min.js v4.0.2
-const LIVE_RELOAD: &str = include_str!("../resources/assets/livereload.js");
-
-async fn is_template_change(event: &notify::Event) -> Result<bool> {
-    let mut parent_dir = event
-        .paths
-        .first()
-        .unwrap()
-        .parent()
-        .as_mut()
-        .unwrap()
-        .to_path_buf();
-    let is_template_dir = fs::find_in_previous_dirs("dir", "templates", &mut parent_dir)
-        .await
-        .is_ok();
-
-    // Filter events to only trigger reloading on meaningful changes
-    let is_template = event
-        .paths
-        .first()
-        .unwrap()
-        .extension()
-        .map(|ext| ext == "html")
-        .unwrap_or(false);
-
-    let is_template_change = matches!(
-        event.kind,
-        notify::EventKind::Create(_)
-            | notify::EventKind::Remove(_)
-            | notify::EventKind::Modify(notify::event::ModifyKind::Data(_))
-    );
-
-    Ok(is_template_dir && is_template && is_template_change)
-}
-
-async fn is_content_change(event: &notify::Event) -> Result<bool> {
-    let event_path = event.paths.first().as_mut().unwrap().to_path_buf();
-    let mut parent_dir = event_path.parent().as_mut().unwrap().to_path_buf();
-    let is_content_dir = fs::find_in_previous_dirs("dir", "content", &mut parent_dir)
-        .await
-        .is_ok();
-
-    // Filter events to only trigger reloading on meaningful changes
-    // NOTE: we do not check for the norg filetype here because content directory
-    // can also hold assets like images, and we want to also trigger a reload when
-    // an asset file is created, modified or removed.
-    let is_content_change = matches!(
-        event.kind,
-        notify::EventKind::Create(_)
-            | notify::EventKind::Remove(_)
-            | notify::EventKind::Modify(notify::event::ModifyKind::Data(_))
-    );
-
-    Ok(is_content_dir && is_content_change)
-}
-
-async fn is_asset_change(event: &notify::Event) -> Result<bool> {
-    let event_path = event.paths.first().unwrap();
-    let mut parent_dir = event_path.parent().as_mut().unwrap().to_path_buf();
-    let is_assets_dir = fs::find_in_previous_dirs("dir", "assets", &mut parent_dir)
-        .await
-        .is_ok();
-
-    // Filter events to only trigger reloading on meaningful changes
-    // NOTE: we do not check for any filetype here because assets directory
-    // can hold assets like css, javascript, images, etc and we want to
-    // trigger a reload when any asset file is created, modified or removed.
-    let is_asset_change = matches!(
-        event.kind,
-        notify::EventKind::Create(_)
-            | notify::EventKind::Remove(_)
-            | notify::EventKind::Modify(notify::event::ModifyKind::Data(_))
-    );
-
-    Ok(is_assets_dir && is_asset_change)
-}
-
-async fn handle_asset(
-    request_path: &str,
-    site_assets_dir: &Path,
-    theme_assets_dir: &Path,
-) -> Result<Response<Body>> {
-    let asset_path = request_path.trim_start_matches("/assets/");
-
-    // Check site assets first
-    let site_path = site_assets_dir.join(asset_path);
-    match tokio::fs::read(&site_path).await {
-        Ok(content) => {
-            let mime_type = mime_guess::from_path(asset_path).first_or_octet_stream();
-
-            Ok(Response::builder()
-                .header(CONTENT_TYPE, mime_type.as_ref())
-                .status(StatusCode::OK)
-                .body(Body::from(content))?)
-        }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            println!("Fallback to theme assets...");
-            let theme_path = theme_assets_dir.join(asset_path);
-            let mut found_theme_asset = false;
-            let theme_asset = match tokio::fs::read(&theme_path).await {
-                Ok(content) => {
-                    let mime_type = mime_guess::from_path(asset_path).first_or_octet_stream();
-                    found_theme_asset = true;
-                    Ok(Response::builder()
-                        .header(CONTENT_TYPE, mime_type.as_ref())
-                        .status(StatusCode::OK)
-                        .body(Body::from(content))?)
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    Ok(Response::builder()
-                        .status(StatusCode::NOT_FOUND)
-                        .body(Body::from("404 Asset Not Found"))?)
-                }
-                Err(e) => {
-                    eprintln!("[server] Error reading asset: {}", e);
-                    Ok(Response::builder()
-                        .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(Body::from("500 Internal Server Error"))?)
-                }
-            };
-
-            if !found_theme_asset {
-                eprintln!("[server] Asset not found: {}", asset_path);
-                return Ok(Response::builder()
-                    .status(StatusCode::NOT_FOUND)
-                    .body(Body::from("404 Asset Not Found"))?);
-            }
-            theme_asset
-        }
-        Err(e) => {
-            eprintln!("[server] Error reading asset: {}", e);
-            Ok(Response::builder()
-                .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(Body::from("500 Internal Server Error"))?)
+impl SitePaths {
+    /// Creates a new `SitePaths` instance based on the provided root directory.
+    ///
+    /// This function initializes the paths for the content, assets, templates, and
+    /// theme-specific directories by joining the root directory with the respective
+    /// subdirectories.
+    ///
+    /// # Arguments
+    /// * `root` - The root directory of the Norgolith site.
+    ///
+    /// # Returns
+    /// * `SitePaths` - A new instance of `SitePaths` with the initialized directory paths.
+    fn new(root: PathBuf) -> Self {
+        Self {
+            content: root.join("content"),
+            assets: root.join("assets"),
+            theme_assets: root.join("theme/assets"),
+            theme_templates: root.join("theme/templates"),
+            templates: root.join("templates"),
         }
     }
 }
 
-async fn handle_websocket(stream: TcpStream, reload_tx: broadcast::Sender<()>) {
+/// Global state for the server, including reloading functionality.
+///
+/// This struct holds the shared state for the server, including the WebSocket reload
+/// channel, Tera templates, site configuration, directory paths, and server settings.
+/// It is used to manage the server's runtime state and facilitate communication
+/// between components.
+struct ServerState {
+    reload_tx: Arc<broadcast::Sender<()>>,
+    tera: Arc<RwLock<Tera>>,
+    config: config::SiteConfig,
+    paths: SitePaths,
+    build_drafts: bool,
+    port: u16,
+}
+
+impl ServerState {
+    /// Reloads the Tera templates.
+    ///
+    /// This function triggers a full reload of the Tera templates. It is called when
+    /// changes to template files are detected. If the reload fails, an error is returned.
+    ///
+    /// # Returns
+    /// * `Result<()>` - `Ok(())` if the templates are reloaded successfully, otherwise
+    ///   an error is returned.
+    async fn reload_templates(&self) -> Result<()> {
+        let mut tera = self.tera.write().await;
+        tera.full_reload()
+            .map_err(|e| eyre!("Failed to reload templates: {}", e))?;
+        Ok(())
+    }
+
+    /// Sends a reload signal to connected WebSocket clients.
+    ///
+    /// This function sends a signal to all connected WebSocket clients to trigger
+    /// a page reload. It is used when changes to assets, templates, or content are
+    /// detected. If the signal fails to send, an error is returned.
+    ///
+    /// # Returns
+    /// * `Result<()>` - `Ok(())` if the signal is sent successfully, otherwise
+    ///   an error is returned.
+    fn send_reload(&self) -> Result<()> {
+        self.reload_tx
+            .send(())
+            .map(|_| ())
+            .map_err(|e| eyre!("Failed to send reload signal: {}", e))
+    }
+}
+
+/// Represents actions to be taken based on file changes.
+///
+/// This struct defines the actions that should be performed when file system events
+/// are detected. It includes flags for reloading templates and assets, as well as
+/// lists of paths to rebuild or clean up.
+#[derive(Default)]
+struct FileActions {
+    reload_templates: bool,
+    reload_assets: bool,
+    rebuild_paths: Vec<PathBuf>,
+    cleanup_paths: Vec<PathBuf>,
+}
+
+/// LiveReload script to be injected into HTML pages.
+///
+/// The LiveReload script version in use is v4.0.2
+const LIVE_RELOAD_SCRIPT: &str = include_str!("../resources/assets/livereload.js");
+/// Port for the LiveReload WebSocket server
+const LIVE_RELOAD_PORT: u16 = 35729;
+/// WebSocket hello message for LiveReload protocol
+const WS_HELLO_MESSAGE: &str = r#"{"command":"hello","protocols":["http://livereload.com/protocols/official-7"],"serverName":"norgolith"}"#;
+/// WebSocket reload message for LiveReload protocol
+const WS_RELOAD_MESSAGE: &str = r#"{"command":"reload","path":"/"}"#;
+
+/// Checks if a file system event is relevant for triggering a reload.
+///
+/// This function determines whether a file system event should trigger a reload
+/// based on its type. It considers events such as file creation, removal, and
+/// data modification as relevant.
+///
+/// # Arguments
+/// * `event` - The file system event to check.
+///
+/// # Returns
+/// * `bool` - `true` if the event is relevant, `false` otherwise.
+fn is_relevant_event(event: &notify::Event) -> bool {
+    matches!(
+        event.kind,
+        notify::EventKind::Create(_)
+            | notify::EventKind::Remove(_)
+            | notify::EventKind::Modify(notify::event::ModifyKind::Data(_))
+    )
+}
+
+/// Checks if a file system event corresponds to a template change.
+///
+/// This function determines whether the event is relevant to the templates directory
+/// and whether it should trigger a template reload. It checks if the file has an
+/// `.html` extension and is located within the templates directory.
+///
+/// # Arguments
+/// * `event` - The file system event to check.
+///
+/// # Returns
+/// * `Result<bool>` - `true` if the event is a template change, `false` otherwise.
+///   Returns an error if the event paths are empty or if the parent directory cannot be determined.
+async fn is_template_change(event: &notify::Event) -> Result<bool> {
+    let path = event.paths.first().ok_or(eyre!("Empty event paths"))?;
+    let is_template = path.extension().is_some_and(|ext| ext == "html");
+    let parent_dir = path.parent().ok_or(eyre!("Path has no parent"))?;
+
+    Ok(
+        fs::find_in_previous_dirs("dir", "templates", &mut parent_dir.to_path_buf())
+            .await
+            .is_ok()
+            && is_template
+            && is_relevant_event(event),
+    )
+}
+
+/// Checks if a file system event corresponds to a content change.
+///
+/// This function determines whether the event is relevant to the content directory
+/// and whether it should trigger a content rebuild. It does not check for specific
+/// file types (e.g., `.norg` files) because the content directory may also contain
+/// assets like images, and changes to these files should also trigger a reload.
+///
+/// # Arguments
+/// * `event` - The file system event to check.
+///
+/// # Returns
+/// * `Result<bool>` - `true` if the event is a content change, `false` otherwise.
+///   Returns an error if the event paths are empty or if the parent directory cannot be determined.
+async fn is_content_change(event: &notify::Event) -> Result<bool> {
+    // NOTE: we do not check for the norg filetype here because content directory
+    // can also hold assets like images, and we want to also trigger a reload when
+    // an asset file is created, modified or removed.
+    let path = event.paths.first().ok_or(eyre!("Empty event paths"))?;
+    let parent_dir = path.parent().ok_or(eyre!("Path has no parent"))?;
+
+    Ok(
+        fs::find_in_previous_dirs("dir", "content", &mut parent_dir.to_path_buf())
+            .await
+            .is_ok()
+            && is_relevant_event(event),
+    )
+}
+
+/// Checks if a file system event corresponds to an asset change.
+///
+/// This function determines whether the event is relevant to the assets directory
+/// and whether it should trigger an asset reload. It does not check for specific
+/// file types because the assets directory can contain various file types (e.g., CSS, JS, images).
+///
+/// # Arguments
+/// * `event` - The file system event to check.
+///
+/// # Returns
+/// * `Result<bool>` - `true` if the event is an asset change, `false` otherwise.
+///   Returns an error if the event paths are empty or if the parent directory cannot be determined.
+async fn is_asset_change(event: &notify::Event) -> Result<bool> {
+    // NOTE: we do not check for any filetype here because assets directory
+    // can hold assets like css, javascript, images, etc and we want to
+    // trigger a reload when any asset file is created, modified or removed.
+    let path = event.paths.first().ok_or(eyre!("Empty event paths"))?;
+    let parent_dir = path.parent().ok_or(eyre!("Path has no parent"))?;
+
+    Ok(
+        fs::find_in_previous_dirs("dir", "assets", &mut parent_dir.to_path_buf())
+            .await
+            .is_ok()
+            && is_relevant_event(event),
+    )
+}
+
+/// Processes debounced file system events and triggers appropriate actions.
+///
+/// This function handles the result of debounced file system events. If the events
+/// are valid, it processes them to determine the necessary actions (e.g., reloading
+/// templates, rebuilding content). If there are errors in the watcher, it logs them.
+///
+/// # Arguments
+/// * `result` - The result of the debounced file system events.
+/// * `state` - The shared server state.
+async fn process_debounced_events(result: DebounceEventResult, state: Arc<ServerState>) {
+    match result {
+        DebounceEventResult::Ok(events) => handle_file_events(events, state).await,
+        DebounceEventResult::Err(errors) => {
+            eprintln!("Watcher errors: {:?}", errors);
+        }
+    }
+}
+
+/// Executes actions based on file changes, such as reloading assets or templates.
+///
+/// This function processes the actions determined by file system events, such as
+/// reloading assets, reloading templates, cleaning up orphaned files, or rebuilding
+/// content. It logs the results of these actions.
+///
+/// # Arguments
+/// * `actions` - The actions to execute.
+/// * `state` - The shared server state.
+async fn execute_actions(actions: FileActions, state: Arc<ServerState>) {
+    // Handle asset reloads
+    if actions.reload_assets {
+        if let Err(e) = state.send_reload() {
+            eprintln!("Asset reload error: {}", e);
+        }
+    }
+
+    // Handle template reloads
+    if actions.reload_templates {
+        match state.reload_templates().await {
+            Ok(_) => {
+                println!("Templates reloaded successfully");
+                if let Err(e) = state.send_reload() {
+                    eprintln!("Template reload signal error: {}", e);
+                }
+            }
+            Err(e) => eprintln!("Template reload failed: {}", e),
+        }
+    }
+
+    // Clean up deleted files
+    for path in &actions.cleanup_paths {
+        if let Err(e) = tokio::fs::remove_file(path).await {
+            eprintln!("Failed to clean up file {}: {}", path.display(), e);
+        } else {
+            println!("Cleaned up orphaned file: {}", path.display());
+        }
+    }
+
+    // Rebuild changed content
+    for path in actions.rebuild_paths {
+        let state = Arc::clone(&state);
+        let content_path = match path.strip_prefix(&state.paths.content) {
+            Ok(p) => p.to_path_buf(),
+            Err(_) => continue,
+        };
+
+        tokio::spawn(async move {
+            let start = std::time::Instant::now();
+            let root_url = format!("http://localhost:{}", state.port);
+
+            match shared::convert_document(
+                &path,
+                &state.paths.content,
+                state.build_drafts,
+                &root_url,
+            )
+            .await
+            {
+                Ok(_) => {
+                    println!(
+                        "Regenerated content: {} ({:.1?})",
+                        content_path.display(),
+                        start.elapsed()
+                    );
+
+                    // Validate metadata if schema exists
+                    if let Some(schema) = &state.config.content_schema {
+                        validate_content_metadata(&path, &state, schema).await;
+                    }
+
+                    if let Err(e) = state.send_reload() {
+                        eprintln!("Reload signal error: {}", e);
+                    }
+                }
+                Err(e) => eprintln!("Content conversion failed: {}", e),
+            }
+        });
+    }
+}
+
+/// Helper function to handle content retrieval errors.
+///
+/// This function retrieves content from a given path and handles errors gracefully.
+/// If the content is not found, it returns a custom error message. For other errors,
+/// it provides detailed error information.
+///
+/// # Arguments
+/// * `request_path` - The path to the content to retrieve.
+///
+/// # Returns
+/// * `Result<(String, PathBuf)>` - A tuple containing the content and its path if successful.
+///   Returns an error if the content cannot be retrieved.
+async fn get_content_or_error(request_path: &str) -> Result<(String, PathBuf)> {
+    shared::get_content(request_path).await.map_err(|e| {
+        if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+            if io_err.kind() == std::io::ErrorKind::NotFound {
+                eyre!("Path not found: {}", request_path)
+            } else {
+                eyre!("Error reading '{}': {}", request_path, io_err)
+            }
+        } else {
+            eyre!("Unexpected error for '{}': {}", request_path, e)
+        }
+    })
+}
+
+/// Loads metadata from a TOML file.
+///
+/// This function reads metadata from a TOML file and returns it as a `toml::Value`.
+/// If the file cannot be read or parsed, it logs the error and returns an empty table.
+///
+/// # Arguments
+/// * `path` - The path to the metadata file.
+///
+/// # Returns
+/// * `toml::Value` - The parsed metadata or an empty table if an error occurs.
+async fn load_metadata(path: PathBuf) -> toml::Value {
+    match tokio::fs::read_to_string(&path).await {
+        Ok(content) => toml::from_str(&content).unwrap_or_else(|e| {
+            eprintln!("Metadata parse error: {}", e);
+            toml::Value::Table(toml::map::Map::new())
+        }),
+        Err(e) => {
+            eprintln!("Metadata file not found: {}", e);
+            toml::Value::Table(toml::map::Map::new())
+        }
+    }
+}
+
+/// Validates content metadata against a schema.
+///
+/// This function validates the metadata of a content file against a provided schema.
+/// If validation errors are found, they are logged in a user-friendly format.
+///
+/// # Arguments
+/// * `path` - The path to the content file.
+/// * `state` - The shared server state.
+/// * `schema` - The schema to validate the metadata against.
+async fn validate_content_metadata(path: &Path, state: &Arc<ServerState>, schema: &ContentSchema) {
+    let build_dir = state.paths.content.parent().unwrap().join(".build");
+    let relative_path = path.strip_prefix(&state.paths.content).unwrap();
+    let meta_path = build_dir.join(relative_path).with_extension("meta.toml");
+
+    let metadata = match tokio::fs::read_to_string(&meta_path).await {
+        Ok(content) => toml::from_str(&content).unwrap_or_else(|e| {
+            eprintln!("Metadata parse error: {}", e);
+            toml::Value::Table(toml::map::Map::new())
+        }),
+        Err(e) => {
+            eprintln!("Metadata file read error: {}", e);
+            return;
+        }
+    };
+    let metadata_map = metadata
+        .as_table()
+        .unwrap()
+        .iter()
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    let content_path = relative_path
+        .to_str()
+        .unwrap()
+        .replace('\\', "/")
+        .trim_end_matches(".norg")
+        .to_string();
+
+    let schema_nodes = schema.resolve_path(&content_path);
+    let merged_schema = ContentSchema::merge_hierarchy(&schema_nodes);
+    let errors = validate_metadata(&metadata_map, &merged_schema);
+
+    if !errors.is_empty() {
+        let error_output = format_errors(path, &content_path, &errors, true);
+        eprintln!("Metadata validation errors:\n{}", error_output);
+    }
+}
+
+/// Injects the LiveReload script into HTML content.
+///
+/// This function modifies the provided HTML string by inserting the LiveReload script
+/// just before the closing `</body>` tag. The script enables automatic page reloading
+/// when changes are detected.
+///
+/// # Arguments
+/// * `html` - The HTML content to modify.
+fn inject_livereload_script(html: &mut String) {
+    if let Some(pos) = html.rfind("</body>") {
+        html.insert_str(
+            pos,
+            &format!(
+                r#"<script src="/livereload.js?port={}&amp;mindelay=10"></script>"#,
+                LIVE_RELOAD_PORT
+            ),
+        );
+    }
+}
+
+/// Reads an asset file and returns its content and MIME type.
+///
+/// This function reads the content of an asset file and determines its MIME type
+/// based on the file extension. It is used to serve static assets like CSS, JS, and images.
+///
+/// # Arguments
+/// * `path` - The path to the asset file.
+///
+/// # Returns
+/// * `Result<(Vec<u8>, String)>` - A tuple containing the file content and its MIME type.
+///   Returns an error if the file cannot be read.
+async fn read_asset(path: &Path) -> Result<(Vec<u8>, String)> {
+    let content = tokio::fs::read(path).await?;
+    let mime_type = mime_guess::from_path(path)
+        .first_or_octet_stream()
+        .as_ref()
+        .to_string();
+    Ok((content, mime_type))
+}
+
+/// Handles file system events and updates the server state accordingly.
+///
+/// This function processes a list of debounced file system events and determines the
+/// necessary actions (e.g., reloading templates, rebuilding content). It updates the
+/// server state based on the detected changes.
+///
+/// # Arguments
+/// * `events` - The list of file system events to process.
+/// * `state` - The shared server state.
+async fn handle_file_events(
+    events: Vec<notify_debouncer_full::DebouncedEvent>,
+    state: Arc<ServerState>,
+) {
+    let mut actions = FileActions::default();
+
+    for event in events {
+        if let Some(path) = event.paths.first() {
+            handle_single_event(&event, path, &mut actions, &state).await;
+        }
+    }
+
+    execute_actions(actions, state).await;
+}
+
+/// Handles a single file system event and updates the actions to be taken.
+///
+/// This function processes a single file system event and updates the `FileActions`
+/// struct to reflect the necessary actions (e.g., reloading templates, rebuilding content).
+/// It ignores temporary backup files (e.g., from NeoVim) to avoid unnecessary reloads.
+///
+/// # Arguments
+/// * `event` - The file system event to process.
+/// * `path` - The path associated with the event.
+/// * `actions` - The actions to update based on the event.
+/// * `state` - The shared server state.
+async fn handle_single_event(
+    event: &notify::Event,
+    path: &Path,
+    actions: &mut FileActions,
+    state: &Arc<ServerState>,
+) {
+    // We are excluding these fucking temp (Neo)vim backup files because they trigger
+    // stupid bugs that I'm not willing to debug anymore.
+    //
+    // TODO: also ignore swap files, my mental health will thank me later.
+    if path.to_string_lossy().ends_with('~') {
+        return;
+    }
+
+    if is_template_change(event).await.unwrap_or(false)
+        && path.strip_prefix(&state.paths.templates).is_ok()
+    {
+        println!(
+            "Template modified: {}",
+            path.strip_prefix(&state.paths.templates).unwrap().display()
+        );
+        actions.reload_templates = true;
+    }
+
+    if is_asset_change(event).await.unwrap_or(false)
+        && path.strip_prefix(&state.paths.assets).is_ok()
+    {
+        println!(
+            "Asset modified: {}",
+            path.strip_prefix(&state.paths.assets).unwrap().display()
+        );
+        actions.reload_assets = true;
+    }
+
+    match event.kind {
+        notify::EventKind::Remove(_) => {
+            handle_removed_file(path, actions, state).await;
+        }
+        _ => {
+            if is_content_change(event).await.unwrap_or(false)
+                && path.strip_prefix(&state.paths.content).is_ok()
+            {
+                // XXX: we are already sending a message when the content is regenerated
+                // do we still want to keep this one?
+                // println!(
+                //     "Content modified: {}",
+                //     path.strip_prefix(&state.paths.content).unwrap().display()
+                // );
+                actions.rebuild_paths.push(path.to_owned());
+            }
+        }
+    }
+}
+
+/// Handles the removal of a file and updates the cleanup actions.
+///
+/// This function processes the removal of a file and updates the `FileActions` struct
+/// to include cleanup actions for associated build files (e.g., HTML and metadata files).
+///
+/// # Arguments
+/// * `path` - The path of the removed file.
+/// * `actions` - The actions to update based on the removal.
+/// * `state` - The shared server state.
+async fn handle_removed_file(path: &Path, actions: &mut FileActions, state: &Arc<ServerState>) {
+    if let Ok(relative_path) = path.strip_prefix(&state.paths.content) {
+        if relative_path.extension().is_some_and(|ext| ext == "norg") {
+            let build_path = Path::new(".build").join(relative_path);
+            actions.cleanup_paths.extend([
+                build_path.with_extension("html"),
+                build_path.with_extension("meta.toml"),
+            ]);
+        }
+    }
+}
+
+/// Handles requests for static assets.
+///
+/// This function serves static assets from the assets directory or the theme assets directory
+/// if the file is not found in the primary assets directory. It returns a `Response` with
+/// the file content and appropriate MIME type.
+///
+/// # Arguments
+/// * `request_path` - The path of the requested asset.
+/// * `paths` - The site directory paths.
+///
+/// # Returns
+/// * `Result<Response<Body>>` - A `Response` containing the asset content or a 404 error
+///   if the asset is not found.
+async fn handle_asset(request_path: &str, paths: &SitePaths) -> Result<Response<Body>> {
+    let asset_path = request_path.trim_start_matches("/assets/");
+    let site_path = paths.assets.join(asset_path);
+
+    match read_asset(&site_path).await {
+        Ok((content, mime_type)) => Ok(Response::builder()
+            .header(CONTENT_TYPE, mime_type)
+            .status(StatusCode::OK)
+            .body(Body::from(content))?),
+        Err(_) => {
+            // Fallback to theme assets
+            let theme_path = paths.theme_assets.join(asset_path);
+            match read_asset(&theme_path).await {
+                Ok((content, mime_type)) => Ok(Response::builder()
+                    .header(CONTENT_TYPE, mime_type)
+                    .status(StatusCode::OK)
+                    .body(Body::from(content))?),
+                Err(_) => Ok(Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Body::from("404 Asset Not Found"))?),
+            }
+        }
+    }
+}
+
+/// Handles requests for static assets with a given content and path.
+///
+/// This function serves static assets directly from provided content and path. It determines
+/// the MIME type based on the file extension and returns a `Response` with the content.
+///
+/// # Arguments
+/// * `content` - The content of the asset.
+/// * `path` - The path of the asset.
+///
+/// # Returns
+/// * `Result<Response<Body>>` - A `Response` containing the asset content.
+async fn handle_static_asset(content: &str, path: &Path) -> Result<Response<Body>> {
+    let mime_type = mime_guess::from_path(path)
+        .first_or_octet_stream()
+        .as_ref()
+        .to_string();
+
+    Ok(Response::builder()
+        .header(
+            CONTENT_TYPE,
+            HeaderValue::from_str(&mime_type)
+                .unwrap_or_else(|_| HeaderValue::from_static("text/plain")),
+        )
+        .status(StatusCode::OK)
+        .body(Body::from(content.to_owned()))?)
+}
+
+/// Handles requests for content, either static or dynamic.
+///
+/// This function serves content from the content directory. If the content is a static file
+/// (e.g., an image), it serves it directly. Otherwise, it renders the content as HTML
+/// using Tera templates.
+///
+/// # Arguments
+/// * `request_path` - The path of the requested content.
+/// * `state` - The shared server state.
+///
+/// # Returns
+/// * `Result<Response<Body>>` - A `Response` containing the content or an error if the
+///   content cannot be retrieved or rendered.
+async fn handle_content(request_path: &str, state: Arc<ServerState>) -> Result<Response<Body>> {
+    let normalized_path = request_path.trim_end_matches('/');
+    let (content, path) = get_content_or_error(normalized_path).await?;
+
+    if normalized_path.contains('.') {
+        handle_static_asset(&content, &path).await
+    } else {
+        handle_html_content(&content, &path, state).await
+    }
+}
+
+/// Handles requests for HTML content, rendering it with Tera templates.
+///
+/// This function renders HTML content using Tera templates and injects the LiveReload script
+/// into the rendered HTML. It also loads metadata associated with the content and passes it
+/// to the template context.
+///
+/// # Arguments
+/// * `content` - The content to render.
+/// * `path` - The path of the content.
+/// * `state` - The shared server state.
+///
+/// # Returns
+/// * `Result<Response<Body>>` - A `Response` containing the rendered HTML or an error if
+///   rendering fails.
+async fn handle_html_content(
+    content: &str,
+    path: &Path,
+    state: Arc<ServerState>,
+) -> Result<Response<Body>> {
+    let meta_path = path.with_extension("meta.toml");
+    let metadata = load_metadata(meta_path).await;
+    let layout = metadata
+        .get("layout")
+        .and_then(|v| v.as_str())
+        .unwrap_or("default");
+
+    let mut context = Context::new();
+    context.insert("content", content);
+    context.insert("config", &state.config);
+    context.insert("metadata", &metadata);
+
+    let tera = state.tera.read().await;
+    let mut body = tera
+        .render(&format!("{}.html", layout), &context)
+        .map_err(|e| eyre!("Template error: {}", e))?;
+
+    inject_livereload_script(&mut body);
+    Ok(Response::builder()
+        .header(CONTENT_TYPE, "text/html; charset=utf-8")
+        .status(StatusCode::OK)
+        .body(Body::from(body))?)
+}
+
+/// Handles WebSocket connections for LiveReload functionality.
+///
+/// This function manages WebSocket connections for LiveReload. It sends a hello message
+/// to the client upon connection and listens for reload signals to send reload messages.
+///
+/// # Arguments
+/// * `stream` - The TCP stream for the WebSocket connection.
+/// * `reload_tx` - The broadcast sender for reload signals.
+async fn handle_websocket(stream: TcpStream, reload_tx: Arc<broadcast::Sender<()>>) {
     let mut ws_stream = match accept_async(stream).await {
         Ok(ws) => ws,
         Err(e) => {
@@ -185,26 +733,20 @@ async fn handle_websocket(stream: TcpStream, reload_tx: broadcast::Sender<()>) {
     };
 
     let mut rx = reload_tx.subscribe();
-
-    let _ = ws_stream
+    if let Err(e) = ws_stream
         .send(tokio_tungstenite::tungstenite::Message::Text(
-            r#"{
-        "command": "hello",
-        "protocols": ["http://livereload.com/protocols/official-7"],
-        "serverName": "norgolith"
-    }"#
-            .to_string()
-            .into(),
+            WS_HELLO_MESSAGE.into(),
         ))
-        .await;
+        .await
+    {
+        eprintln!("[server] Failed to send hello message: {}", e);
+        return;
+    }
 
     loop {
         tokio::select! {
             _ = rx.recv() => {
-                if let Err(e) = ws_stream.send(tokio_tungstenite::tungstenite::Message::Text(r#"{
-                    "command": "reload",
-                    "path": "/"
-                }"#.to_string().into())).await {
+                if let Err(e) = ws_stream.send(tokio_tungstenite::tungstenite::Message::Text(WS_RELOAD_MESSAGE.into())).await {
                     eprintln!("WebSocket send error: {}", e);
                     break;
                 }
@@ -223,485 +765,241 @@ async fn handle_websocket(stream: TcpStream, reload_tx: broadcast::Sender<()>) {
     }
 }
 
+/// Handles HTTP requests and routes them to the appropriate handler.
+///
+/// This function processes incoming HTTP requests and routes them to the appropriate
+/// handler based on the request path. It serves LiveReload scripts, static assets, and
+/// dynamic content.
+///
+/// # Arguments
+/// * `req` - The incoming HTTP request.
+/// * `state` - The shared server state.
+///
+/// # Returns
+/// * `Result<Response<Body>>` - A `Response` containing the result of the request handling.
 async fn handle_request(req: Request<Body>, state: Arc<ServerState>) -> Result<Response<Body>> {
-    let request_path = req.uri().path().to_owned();
+    let request_path = req.uri().path();
 
-    // Handle assets first
-    if request_path.starts_with("/assets/") {
-        return handle_asset(&request_path, &state.assets_dir, &state.theme_assets_dir).await;
-    }
-
-    // Handle reload endpoint
-    if request_path == "/livereload.js" {
-        return Ok(Response::builder()
+    match request_path {
+        "/livereload.js" => Ok(Response::builder()
             .header(CONTENT_TYPE, "text/javascript")
-            .status(StatusCode::OK)
-            .body(LIVE_RELOAD.into())?);
-    }
-
-    // Helper function to handle content retrieval errors
-    async fn get_content_or_error(request_path: &str) -> Result<(String, PathBuf)> {
-        shared::get_content(request_path).await.map_err(|e| {
-            if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
-                if io_err.kind() == std::io::ErrorKind::NotFound {
-                    eyre!("Path not found: {}", request_path)
-                } else {
-                    eyre!("Error reading '{}': {}", request_path, io_err)
-                }
-            } else {
-                eyre!("Unexpected error for '{}': {}", request_path, e)
-            }
-        })
-    }
-
-    // Normalize path for content handling
-    let normalized_path = if request_path.ends_with('/') {
-        request_path.trim_end_matches('/').to_owned()
-    } else {
-        request_path.clone()
-    };
-
-    let response = if !normalized_path.contains('.') {
-        // HTML content handling
-        match get_content_or_error(&normalized_path).await {
-            Ok((path_contents, html_path)) => {
-                // Get metadata path, derive it from actual HTML file path
-                let meta_path = html_path.with_extension("meta.toml");
-
-                // Handle metadata loading with proper error fallback
-                let metadata: toml::Value = match tokio::fs::read_to_string(meta_path.clone()).await
-                {
-                    Ok(content) => toml::from_str(&content).unwrap_or_else(|e| {
-                        // Fallback to empty table on parse errors
-                        eprintln!("[server] Failed to parse metadata: {}", e);
-                        toml::Value::Table(toml::map::Map::new())
-                    }),
-                    Err(e) => {
-                        // Fallback to empty table if file not found
-                        eprintln!("[server] Metadata file not found: {}", e);
-                        toml::Value::Table(toml::map::Map::new())
-                    }
-                };
-
-                // Get the layout (template) to render the content, fallback to default if the metadata field was not found.
-                let layout = metadata
-                    .get("layout")
-                    .unwrap_or(&toml::Value::from("default"))
-                    .as_str()
-                    .unwrap()
-                    .to_owned();
-
-                // Build template context
-                let mut context = Context::new();
-                context.insert("content", &path_contents);
-                context.insert("config", &state.config);
-                context.insert("metadata", &metadata);
-
-                // Get the template to use for rendering
-                let tera = state.tera.read().await;
-                tera.render(&(layout + ".html"), &context)
-                    .map(|body| {
-                        Response::builder()
-                            .header(CONTENT_TYPE, "text/html; charset=utf-8")
-                            .status(StatusCode::OK)
-                            .body(Body::from(body))
-                            .unwrap()
-                    })
-                    .map_err(|e| eyre!("Template rendering error for '{}': {}", normalized_path, e))
-            }
-            Err(e) => Err(e),
-        }
-    } else {
-        match get_content_or_error(&normalized_path).await {
-            Ok((path_contents, asset_path)) => {
-                // Static assets handling
-                //
-                // Set content type based on file extension
-                let mime_type = mime_guess::from_path(asset_path).first_or_octet_stream();
-                Ok(Response::builder()
-                    .header(
-                        CONTENT_TYPE,
-                        HeaderValue::from_str(mime_type.as_ref())
-                            .unwrap_or_else(|_| HeaderValue::from_static("text/plain")),
-                    )
-                    .status(StatusCode::OK)
-                    .body(Body::from(path_contents))?)
-            }
-            Err(e) => Err(e),
-        }
-    };
-
-    // Inject livereload script into HTML responses
-    match response {
-        Ok(mut response) => {
-            if let Some(content_type) = response.headers().get(CONTENT_TYPE) {
-                if content_type.to_str().unwrap() == "text/html; charset=utf-8" {
-                    let body = hyper::body::to_bytes(response.body_mut()).await?;
-                    let mut html = String::from_utf8(body.to_vec())?;
-
-                    // Inject reload script before closing body tag, it does reload every second
-                    if let Some(pos) = html.rfind("</body>") {
-                        html.insert_str(
-                            pos,
-                            r#"<script src="/livereload.js?port=35729&amp;mindelay=10"></script>"#,
-                        );
-                    }
-                    *response.body_mut() = Body::from(html);
-                }
-            }
-            Ok(response)
-        }
-        Err(e) => {
-            // Single error logging point
-            eprintln!("[server] {}", e);
-            if e.to_string().contains("Path not found") {
-                // TODO: add a 404 template using Tera
-                Ok(Response::builder()
-                    .status(StatusCode::NOT_FOUND)
-                    .body(Body::from("404 Not Found"))?)
-            } else {
-                // TODO: add a 500 template using Tera
-                Ok(Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(Body::from("500 Internal Server Error"))?)
-            }
-        }
+            .body(LIVE_RELOAD_SCRIPT.into())?),
+        path if path.starts_with("/assets/") => handle_asset(path, &state.paths).await,
+        _ => handle_content(request_path, state).await,
     }
 }
 
+/// Handles HTTP requests and logs the results.
+///
+/// This function wraps the request handling logic and logs the request method, path,
+/// status code, and response time. It ensures that errors are handled gracefully and
+/// returns an appropriate response.
+///
+/// # Arguments
+/// * `req` - The incoming HTTP request.
+/// * `state` - The shared server state.
+///
+/// # Returns
+/// * `Result<Response<Body>, Infallible>` - A `Response` or an error if the request
+///   cannot be handled.
+async fn handle_server_request(
+    req: Request<Body>,
+    state: Arc<ServerState>,
+) -> Result<Response<Body>, Infallible> {
+    let start = std::time::Instant::now();
+    let method = req.method().clone();
+    let uri = req.uri().clone();
+    let path = uri.path().to_owned();
+
+    let response = match handle_request(req, state).await {
+        Ok(res) => res,
+        Err(_e) => {
+            // XXX: this may be too verbose sometimes, do we want to keep it?
+            // eprintln!("Request handling error: {}", e);
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::from("500 Internal Server Error"))
+                .unwrap()
+        }
+    };
+
+    let duration = start.elapsed();
+    let status = response.status();
+
+    if path != "/livereload.js" {
+        println!("{} {} => {} in {:.1?}", method, path, status, duration);
+    }
+
+    Ok(response)
+}
+
+/// Sets up the server state with the necessary configurations.
+///
+/// This function initializes the server state, including loading the site configuration,
+/// setting up Tera templates, and creating the WebSocket reload channel. It ensures that
+/// all components required for the server to function are properly initialized.
+///
+/// # Arguments
+/// * `root` - The root directory of the site.
+/// * `drafts` - Whether to build draft content.
+/// * `port` - The port on which the server will run.
+///
+/// # Returns
+/// * `Result<Arc<ServerState>>` - The initialized server state or an error if setup fails.
+async fn setup_server_state(root: PathBuf, drafts: bool, port: u16) -> Result<Arc<ServerState>> {
+    let config_content = tokio::fs::read_to_string(&root).await?;
+    let site_config: config::SiteConfig = toml::from_str(&config_content)?;
+
+    let root_dir = root.parent().unwrap().to_path_buf();
+    let paths = SitePaths::new(root_dir.clone());
+
+    let tera = Arc::new(RwLock::new(
+        shared::init_tera(paths.templates.to_str().unwrap(), &root_dir.join("theme")).await?,
+    ));
+
+    let (reload_tx, _) = broadcast::channel(16);
+
+    Ok(Arc::new(ServerState {
+        reload_tx: Arc::new(reload_tx),
+        tera,
+        config: site_config,
+        paths,
+        build_drafts: drafts,
+        port,
+    }))
+}
+
+/// Sets up the file watcher for detecting changes in the site directory.
+///
+/// This function initializes a debounced file watcher to monitor changes in the templates,
+/// content, and assets directories. It also watches theme directories if they exist. The
+/// watcher uses a debounce mechanism to avoid triggering multiple events for rapid changes.
+///
+/// # Arguments
+/// * `state` - The shared server state.
+/// * `rt` - The runtime handle for spawning tasks.
+///
+/// # Returns
+/// * `Result<(Debouncer<RecommendedWatcher, RecommendedCache>, impl Stream<Item = DebounceEventResult>)>` -
+///   A tuple containing the debouncer and a stream of debounced events.
+async fn setup_file_watcher(
+    state: Arc<ServerState>,
+    rt: Handle,
+) -> Result<(
+    Debouncer<RecommendedWatcher, RecommendedCache>,
+    impl Stream<Item = DebounceEventResult>,
+)> {
+    let (debouncer_tx, debouncer_rx) = tokio::sync::mpsc::channel(16);
+
+    // Create debouncer with 200ms delay, this should be enough to handle both the
+    // (Neo)vim swap files and also the VSCode atomic saves
+    let mut debouncer: Debouncer<RecommendedWatcher, RecommendedCache> = new_debouncer(
+        Duration::from_millis(200),
+        None,
+        move |result: DebounceEventResult| {
+            let tx = debouncer_tx.clone();
+            rt.spawn(async move {
+                if let Err(e) = tx.send(result).await {
+                    eprintln!("Debouncer error: {:?}", e);
+                }
+            });
+        },
+    )?;
+
+    debouncer.watch(&state.paths.templates, RecursiveMode::Recursive)?;
+    debouncer.watch(&state.paths.content, RecursiveMode::Recursive)?;
+    debouncer.watch(&state.paths.assets, RecursiveMode::Recursive)?;
+    // Watch theme files only if they exist
+    if state.paths.theme_assets.exists() {
+        debouncer.watch(&state.paths.theme_assets, RecursiveMode::Recursive)?;
+    }
+    if state.paths.theme_templates.exists() {
+        debouncer.watch(&state.paths.theme_templates, RecursiveMode::Recursive)?;
+    }
+
+    Ok((debouncer, ReceiverStream::new(debouncer_rx)))
+}
+
+/// Starts the development server.
+///
+/// This function initializes and runs the development server, including the HTTP server,
+/// WebSocket server, and file watcher. It also performs an initial build of the site
+/// content and opens the site in the browser if requested. The server listens for file
+/// changes and triggers reloads or rebuilds as necessary.
+///
+/// # Arguments
+/// * `port` - The port on which the server will run.
+/// * `drafts` - Whether to build draft content.
+/// * `open` - Whether to open the site in the browser after starting the server.
+///
+/// # Returns
+/// * `Result<()>` - `Ok(())` if the server runs successfully, otherwise an error.
 pub async fn serve(port: u16, drafts: bool, open: bool) -> Result<()> {
-    // Try to find a 'norgolith.toml' file in the current working directory and its parents
-    let mut current_dir = std::env::current_dir()?;
-    let found_site_root =
-        fs::find_in_previous_dirs("file", "norgolith.toml", &mut current_dir).await?;
-
-    if let Some(mut root) = found_site_root {
+    let root = fs::find_config_file().await?;
+    if let Some(root) = root {
+        let state = setup_server_state(root, drafts, port).await?;
         let server_start = std::time::Instant::now();
-
-        // Load site configuration, root already contains the norgolith.toml path
-        let config_content = tokio::fs::read_to_string(&root).await?;
-        let site_config: config::SiteConfig = toml::from_str(&config_content)?;
-
-        // Remove `norgolith.toml` from the root path
-        root.pop();
-        let root_dir = root.into_os_string().into_string().unwrap();
-
-        // Tera wants a `dir: &str` parameter for some reason instead of asking for a `&Path` or `&PathBuf`...
-        let templates_dir = root_dir.clone() + "/templates";
-        let content_dir = Path::new(&root_dir.clone()).join("content");
-        let assets_dir = Path::new(&root_dir.clone()).join("assets");
-        let theme_dir = Path::new(&root_dir.clone()).join("theme");
-        let theme_templates_dir = theme_dir.join("templates");
-        let theme_assets_dir = theme_dir.join("assets");
-
-        // Async runtime handle
         let rt = Handle::current();
 
-        // Initialize Tera once
-        let tera = Arc::new(RwLock::new(
-            shared::init_tera(&templates_dir, &theme_dir).await?,
-        ));
-
-        // Create reload channel
-        let (reload_tx, _) = broadcast::channel(16);
-
-        // Start WebSocket server for livereload
-        let reload_tx_clone = reload_tx.clone();
+        // WebSocket server
+        let reload_tx = state.reload_tx.clone();
         tokio::spawn(async move {
-            let listener = TcpListener::bind("127.0.0.1:35729").await.unwrap();
+            let listener = TcpListener::bind(format!("127.0.0.1:{}", LIVE_RELOAD_PORT))
+                .await
+                .unwrap();
             while let Ok((stream, _)) = listener.accept().await {
-                let reload_tx = reload_tx_clone.clone();
-                tokio::spawn(handle_websocket(stream, reload_tx));
+                tokio::spawn(handle_websocket(stream, reload_tx.clone()));
             }
         });
 
-        // Initialize server state
-        let state = Arc::new(ServerState {
-            reload_tx,
-            tera,
-            config: site_config,
-            content_dir: content_dir.clone(),
-            assets_dir: assets_dir.clone(),
-            theme_assets_dir: theme_assets_dir.clone(),
-        });
-        let root_url = state.config.root_url.clone();
-
-        // Create debouncer with 200ms delay, this should be enough to handle both the
-        // (Neo)vim swap files and also the VSCode atomic saves
-        let (debouncer_tx, mut debouncer_rx) = tokio::sync::mpsc::channel(16);
-        let state_watcher = Arc::clone(&state);
-        let mut debouncer = new_debouncer(
-            Duration::from_millis(200),
-            None,
-            move |result: DebounceEventResult| {
-                let tx = debouncer_tx.clone();
-                rt.spawn(async move {
-                    if let Err(e) = tx.send(result).await {
-                        eprintln!("[server] Error sending debouncer result: {:?}", e);
-                    }
-                });
-            },
-        )?;
-
-        // Set up watchers
-        debouncer.watch(Path::new(&templates_dir.clone()), RecursiveMode::Recursive)?;
-        debouncer.watch(Path::new(&content_dir.clone()), RecursiveMode::Recursive)?;
-        debouncer.watch(Path::new(&assets_dir.clone()), RecursiveMode::Recursive)?;
-        debouncer.watch(
-            Path::new(&theme_assets_dir.clone()),
-            RecursiveMode::Recursive,
-        )?;
-        debouncer.watch(
-            Path::new(&theme_templates_dir.clone()),
-            RecursiveMode::Recursive,
-        )?;
-
+        // File watcher and event processing
+        let (debouncer, mut debouncer_rx) = setup_file_watcher(state.clone(), rt.clone()).await?;
+        let state_clone = Arc::clone(&state);
         tokio::spawn(async move {
-            while let Some(result) = debouncer_rx.recv().await {
-                match result {
-                    DebounceEventResult::Ok(events) => {
-                        let mut reload_templates_needed = false;
-                        let mut reload_assets_needed = false;
-                        let mut rebuild_needed = false;
-                        let mut rebuild_document_path = PathBuf::new();
+            // Move debouncer into the async block, otherwise the file watcher does not work at all.
+            // I spent at least hour and a half debugging this and the solution was really this simple...
+            let _debouncer = debouncer;
 
-                        for event in events {
-                            if let notify::EventKind::Remove(_) = &event.kind {
-                                // I hate duplicating code but it makes the borrow checker happy so who cares!
-                                let file_path = event.paths.first().unwrap().clone();
-
-                                // Spawn cleanup task with owned data
-                                let state = Arc::clone(&state_watcher);
-                                let content_dir = state_watcher.content_dir.clone();
-                                tokio::task::spawn(async move {
-                                    if let Ok(relative_path) = file_path.strip_prefix(content_dir) {
-                                        if relative_path
-                                            .extension()
-                                            .map(|e| e == "norg")
-                                            .unwrap_or(false)
-                                        {
-                                            // Create owned paths for async task
-                                            let html_path = Path::new(".build")
-                                                .join(relative_path)
-                                                .with_extension("html");
-                                            let meta_path = html_path.with_extension("meta.toml");
-
-                                            let _ = tokio::fs::remove_file(&html_path).await;
-                                            let _ = tokio::fs::remove_file(&meta_path).await;
-                                            println!("[server] Removed build files for deleted content: {}", relative_path.display());
-
-                                            let _ = state.reload_tx.send(());
-                                        }
-                                    }
-                                });
-                            }
-
-                            let file_path = event.paths.first().unwrap();
-                            let file_name = event
-                                .paths
-                                .first()
-                                .unwrap()
-                                .file_name()
-                                .unwrap()
-                                .to_str()
-                                .unwrap();
-                            if is_template_change(&event).await.unwrap_or(false) {
-                                println!("[server] Detected template change: {}", file_name);
-                                reload_templates_needed = true;
-                            }
-
-                            // We are excluding these fucking temp (Neo)vim backup files because they trigger
-                            // stupid bugs that I'm not willing to debug anymore.
-                            //
-                            // TODO: also ignore swap files, my mental health will thank me later.
-                            if !file_name.ends_with('~') {
-                                if file_path.strip_prefix(&state_watcher.content_dir).is_ok()
-                                    && is_content_change(&event).await.unwrap_or(false)
-                                {
-                                    println!("[server] Detected content change: {}", file_name);
-                                    rebuild_needed = true;
-                                    rebuild_document_path = file_path.to_owned();
-                                }
-
-                                if (file_path.strip_prefix(&state_watcher.assets_dir).is_ok()
-                                    || file_path
-                                        .strip_prefix(&state_watcher.theme_assets_dir)
-                                        .is_ok())
-                                    && is_asset_change(&event).await.unwrap_or(false)
-                                {
-                                    println!("[server] Detected asset change: {}", file_name);
-                                    reload_assets_needed = true;
-                                }
-                            }
-                        }
-
-                        if reload_assets_needed {
-                            let _ = state_watcher.reload_tx.send(());
-                        }
-
-                        if reload_templates_needed {
-                            let mut tera = state_watcher.tera.write().await;
-                            match tera.full_reload() {
-                                Ok(_) => {
-                                    println!("[server] Templates successfully reloaded");
-                                    let _ = state_watcher.reload_tx.send(());
-                                }
-                                Err(e) => eprintln!("[server] Failed to reload templates: {}", e),
-                            }
-                        }
-
-                        if rebuild_needed {
-                            let state = Arc::clone(&state_watcher);
-                            let root_url = format!("http://localhost:{}", port);
-                            let content_schema = state.config.content_schema.clone();
-                            tokio::task::spawn(async move {
-                                match shared::convert_document(
-                                    &rebuild_document_path,
-                                    &state.content_dir,
-                                    drafts,
-                                    &root_url,
-                                )
-                                .await
-                                {
-                                    Ok(_) => {
-                                        let stripped_path = rebuild_document_path
-                                            .strip_prefix(&state.content_dir)
-                                            .unwrap();
-
-                                        if let Some(schema) = &content_schema {
-                                            let content_path = stripped_path
-                                                .to_str()
-                                                .unwrap()
-                                                .replace('\\', "/")
-                                                .trim_end_matches(".norg")
-                                                .to_string();
-
-                                            // Read generated metadata
-                                            let build_dir =
-                                                state.content_dir.parent().unwrap().join(".build");
-                                            let meta_path = build_dir
-                                                .join(stripped_path)
-                                                .with_extension("meta.toml");
-
-                                            if let Ok(metadata_content) =
-                                                tokio::fs::read_to_string(&meta_path).await
-                                            {
-                                                let metadata: toml::Value = toml::from_str(
-                                                    &metadata_content,
-                                                )
-                                                .unwrap_or_else(|e| {
-                                                    // Fallback to empty table on parse errors
-                                                    eprintln!(
-                                                        "[server] Failed to parse metadata: {}",
-                                                        e
-                                                    );
-                                                    toml::Value::Table(toml::map::Map::new())
-                                                });
-                                                let metadata_map = metadata
-                                                    .as_table()
-                                                    .unwrap()
-                                                    .iter()
-                                                    .map(|(k, v)| (k.clone(), v.clone()))
-                                                    .collect();
-
-                                                // Resolve schema
-                                                let schema_nodes =
-                                                    schema.resolve_path(&content_path);
-                                                let merged_schema =
-                                                    ContentSchema::merge_hierarchy(&schema_nodes);
-
-                                                // Validate and report warnings
-                                                let errors = validate_metadata(
-                                                    &metadata_map,
-                                                    &merged_schema,
-                                                );
-                                                if !errors.is_empty() {
-                                                    let error_output = format_errors(
-                                                        &rebuild_document_path,
-                                                        &content_path,
-                                                        &errors,
-                                                        true,
-                                                    );
-                                                    eprintln!("[server] {}", error_output);
-                                                }
-                                            }
-                                        }
-
-                                        println!(
-                                            "[server] Content successfully regenerated: {}",
-                                            stripped_path.display()
-                                        );
-                                        let _ = state.reload_tx.send(());
-                                    }
-                                    Err(e) => eprintln!("[server] Content conversion error: {}", e),
-                                }
-                            });
-                        }
-                    }
-                    DebounceEventResult::Err(errors) => {
-                        eprintln!("[server] Watcher errors: {:?}", errors);
-                    }
-                }
+            while let Some(result) = debouncer_rx.next().await {
+                process_debounced_events(result, state_clone.clone()).await;
             }
         });
 
-        // Create the server binding
-        let make_svc = make_service_fn(move |_conn| {
-            let state = Arc::clone(&state);
+        // HTTP server
+        let state_clone = Arc::clone(&state);
+        let make_svc = make_service_fn(move |_| {
+            let state = state_clone.clone();
             async move {
-                Ok::<_, Infallible>(service_fn(move |req: Request<Body>| {
-                    let start = std::time::Instant::now();
-                    let method = req.method().clone();
-                    let uri = req.uri().clone();
-                    let state = state.clone();
-
-                    async move {
-                        let path = uri.path().to_owned();
-                        let response = handle_request(req, state).await.unwrap();
-                        let status = response.status();
-                        let duration = start.elapsed();
-
-                        if path != "/livereload.js" {
-                            println!(
-                                "[server] {} {} => {} {} in {:.1?}",
-                                method,
-                                path,
-                                status.as_u16(),
-                                status.canonical_reason().unwrap_or("Unknown"),
-                                duration
-                            );
-                        }
-
-                        Ok::<_, Infallible>(response)
-                    }
+                Ok::<_, Infallible>(service_fn(move |req| {
+                    handle_server_request(req, state.clone())
                 }))
             }
         });
+
         let addr = ([127, 0, 0, 1], port).into();
         let server = Server::bind(&addr).serve(make_svc);
-        let uri = format!("http://localhost:{}/", port);
 
-        // Convert the norg documents to html
-        shared::convert_content(&content_dir, drafts, &root_url).await?;
-
-        // Clean up orphaned files before starting server
-        shared::cleanup_orphaned_build_files(&content_dir).await?;
+        // Initial build
+        shared::convert_content(&state.paths.content, drafts, &state.config.root_url).await?;
+        shared::cleanup_orphaned_build_files(&state.paths.content).await?;
 
         println!(
-            "[server] Serving site... Done in {}",
-            shared::get_elapsed_time(server_start)
+            "[server] Server started in {} at http://localhost:{}/",
+            shared::get_elapsed_time(server_start),
+            port
         );
-        println!("[server] Web server is available at {}", uri);
+
         if open {
-            match open::that_detached(uri) {
+            match open::that_detached(format!("http://localhost:{}/", port)) {
                 Ok(()) => {
-                    println!("[server] Opening the development server page using your browser ...")
+                    println!("[server] Opening the development server page using your browser ...");
                 }
                 Err(e) => bail!("[server] Could not open the development server page: {}", e),
-            }
+            };
         }
-        if let Err(err) = server.await {
-            bail!("[server] Server error: {}", err)
+
+        if let Err(e) = server.await {
+            bail!("[server] Server error: {}", e);
         }
     } else {
         bail!("[server] Could not initialize the development server: not in a Norgolith site directory");

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -36,6 +36,15 @@ pub async fn find_in_previous_dirs(
     Ok(None)
 }
 
+pub async fn find_config_file() -> Result<Option<PathBuf>> {
+    // Try to find a 'norgolith.toml' file in the current working directory and its parents
+    let mut current_dir = std::env::current_dir()?;
+    let found_site_root =
+        find_in_previous_dirs("file", "norgolith.toml", &mut current_dir).await?;
+
+    Ok(found_site_root)
+}
+
 pub async fn copy_dir_all(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> Result<()> {
     Box::pin(create_dir_all(&dest)).await?;
     let mut entries = read_dir(&src).await?;


### PR DESCRIPTION
Refactored commands:
- [x] `new`
- [x] `build`
- [x] `serve`

Note for myself: I've added a `find_config_file` function in the `fs` module. I should use it on each command later (already implemented it on `serve`).