### PR TITLE
feat: enable `preserve_order` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2915,6 +2915,7 @@ version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2459,6 +2459,7 @@ version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ eyre = "0.6.12"
 hyper = { version = "=0.14.28", features = ["runtime", "server", "http1", "http2"] }
 tera = "1.20.0"
 tokio = { version = "1.43.0", features = ["fs", "time", "rt-multi-thread", "macros", "process"] }
-toml = "0.8.19"
+toml = { version = "0.8.19", features = ["preserve_order"] }
 rust-norg = { git = "https://github.com/nvim-neorg/rust-norg", branch = "main" }
 whoami = "1.5.2"
 open = "5.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ clap = { version = "4.5.27", features = ["deprecated", "derive", "env", "wrap_he
 comfy-table = "7.1.3"
 eyre = "0.6.12"
 hyper = { version = "=0.14.28", features = ["runtime", "server", "http1", "http2"] }
-tera = "1.20.0"
+tera = { version = "1.20.0", features = ["preserve_order"] }
 tokio = { version = "1.43.0", features = ["fs", "time", "rt-multi-thread", "macros", "process"] }
 toml = { version = "0.8.19", features = ["preserve_order"] }
 rust-norg = { git = "https://github.com/nvim-neorg/rust-norg", branch = "main" }


### PR DESCRIPTION
Enabled `preserve_order` features in both `toml` and `tera` crates. This should avoid any unexpected issue with the order in for loops and such things in the templates.