### PR TITLE
feat: expose posts pages to both server and build

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -102,6 +102,7 @@ async fn generate_public_build(
     site_config: config::SiteConfig,
     minify: bool,
 ) -> Result<()> {
+    let posts = shared::collect_all_posts_metadata(&paths.build, &site_config.root_url).await?;
     let entries = WalkDir::new(&paths.build)
         .into_iter()
         .filter_map(|e| e.ok());
@@ -112,6 +113,7 @@ async fn generate_public_build(
     // Parallel processing
     futures_util::stream::iter(entries)
         .for_each_concurrent(num_cpus::get(), |entry| {
+            let posts = posts.clone();
             let site_config = site_config.clone();
             let validation_errors = Arc::clone(&validation_errors);
 
@@ -123,6 +125,7 @@ async fn generate_public_build(
                     &site_config,
                     minify,
                     &validation_errors,
+                    &posts,
                 )
                 .await
                 {
@@ -144,7 +147,7 @@ async fn generate_public_build(
 ///
 /// Handles template rendering, metadata validation, and output path determination.
 /// Skips draft content and applies minification when enabled.
-#[instrument(skip(tera, paths, site_config, validation_errors))]
+#[instrument(skip(tera, paths, site_config, validation_errors, posts))]
 async fn process_build_entry(
     entry: DirEntry,
     tera: &Tera,
@@ -152,6 +155,7 @@ async fn process_build_entry(
     site_config: &config::SiteConfig,
     minify: bool,
     validation_errors: &Arc<Mutex<Vec<String>>>,
+    posts: &[toml::Value],
 ) -> Result<()> {
     let path = entry.path();
 
@@ -207,6 +211,7 @@ async fn process_build_entry(
         let mut context = Context::new();
         context.insert("content", &html);
         context.insert("config", &site_config);
+        context.insert("posts", &posts);
         context.insert("metadata", &metadata);
 
         // Render template
@@ -337,7 +342,7 @@ async fn write_public_file(public_path: &Path, rendered: String) -> Result<()> {
 fn should_minify_asset(src: &Path) -> bool {
     let file_stem = src.file_stem().and_then(|s| s.to_str()).unwrap_or_default();
     let file_ext = src.extension().and_then(|s| s.to_str()).unwrap_or_default();
-    file_stem != "min" && (file_ext == "js" || file_ext == "css")
+    !file_stem.ends_with(".min") && (file_ext == "js" || file_ext == "css")
 }
 
 /// Minifies HTML content using optimized settings for production builds.

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 use eyre::{bail, eyre, Result};
 use tera::Tera;
 use tracing::{error, info};
+use walkdir::WalkDir;
 
 use crate::converter;
 use crate::schema::{format_errors, validate_metadata, ContentSchema};
@@ -195,16 +196,20 @@ pub async fn init_tera(templates_dir: &str, theme_templates_dir: &Path) -> Resul
     // Initialize Tera with the user-defined templates first
     let mut tera = match Tera::parse(&(templates_dir.to_owned() + "/**/*.html")) {
         Ok(t) => t,
-        Err(e) => bail!("Error parsing templates from the templates directory: {}", e),
+        Err(e) => bail!(
+            "Error parsing templates from the templates directory: {}",
+            e
+        ),
     };
 
     // Theme templates will override the user-defined templates by design if they are named exactly
     // the same in both the user's templates directory and the theme templates directory
     if tokio::fs::try_exists(&theme_templates_dir).await? {
-        let tera_theme = match Tera::parse(&(theme_templates_dir.display().to_string() + "/**/*.html")) {
-            Ok(t) => t,
-            Err(e) => bail!("Error parsing templates from themes: {}", e),
-        };
+        let tera_theme =
+            match Tera::parse(&(theme_templates_dir.display().to_string() + "/**/*.html")) {
+                Ok(t) => t,
+                Err(e) => bail!("Error parsing templates from themes: {}", e),
+            };
         tera.extend(&tera_theme)?;
     }
     tera.build_inheritance_chains()?;
@@ -227,10 +232,23 @@ pub async fn init_tera(templates_dir: &str, theme_templates_dir: &Path) -> Resul
 /// * `toml::Value` - The parsed metadata or an empty table if an error occurs.
 pub async fn load_metadata(path: PathBuf) -> toml::Value {
     match tokio::fs::read_to_string(&path).await {
-        Ok(content) => toml::from_str(&content).unwrap_or_else(|e| {
-            error!("Metadata parse error: {}", e);
-            toml::Value::Table(toml::map::Map::new())
-        }),
+        Ok(content) => {
+            let mut value = toml::from_str(&content).unwrap_or_else(|e| {
+                error!("Metadata parse error: {}", e);
+                toml::Value::Table(toml::map::Map::new())
+            });
+
+            // Convert TOML datetimes to RFC3339 strings
+            if let Some(table) = value.as_table_mut() {
+                for (_k, v) in table.iter_mut() {
+                    if let toml::Value::Datetime(dt) = v {
+                        *v = toml::Value::String(dt.to_string());
+                    }
+                }
+            }
+
+            value
+        }
         Err(e) => {
             error!("Metadata file not found: {}", e);
             toml::Value::Table(toml::map::Map::new())
@@ -285,4 +303,82 @@ pub async fn validate_content_metadata(
         return Ok(format_errors(path, &content_path, &errors, as_warnings));
     }
     Ok(String::new())
+}
+
+pub async fn collect_all_posts_metadata(
+    build_dir: &Path,
+    routes_url: &str,
+) -> Result<Vec<toml::Value>> {
+    let mut posts = Vec::new();
+
+    for entry in WalkDir::new(build_dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let path = e.path();
+            let file_name = path.file_name().and_then(|name| name.to_str());
+            let is_meta_file = file_name.is_some_and(|name| name.ends_with(".meta.toml"));
+            let is_post = path
+                .strip_prefix(build_dir)
+                .is_ok_and(|p| p.starts_with("posts") && !p.ends_with("posts/index.meta.toml"));
+            is_post && is_meta_file
+        })
+    {
+        let meta_path = entry.path();
+        let mut metadata = load_metadata(entry.path().to_path_buf()).await;
+
+        // TODO: this won't hot reload if the content changes, should be passed as an argument instead
+        // Get the raw html content
+        let html_file = entry.path().with_extension("").with_extension("html");
+        let html = tokio::fs::read_to_string(&html_file).await?;
+
+        // Generate permalink from file structure
+        let rel_path = meta_path.strip_prefix(build_dir)?;
+        // Remove .meta.toml
+        let mut permalink_path = rel_path.with_extension("").with_extension("");
+
+        // Handle index pages
+        if let Some(file_name) = permalink_path.file_name() {
+            if file_name == "index" {
+                permalink_path = permalink_path
+                    .parent()
+                    .unwrap_or_else(|| Path::new(""))
+                    .to_path_buf();
+            }
+        }
+
+        // Convert to URL path
+        let permalink_str = permalink_path
+            .to_string_lossy()
+            .trim_start_matches('/')
+            .to_string();
+
+        let permalink = if permalink_str.is_empty() {
+            format!("{}/", routes_url)
+        } else {
+            format!("{}/{}/", routes_url, permalink_str)
+        };
+
+        // Add permalink and html content to metadata
+        if let toml::Value::Table(ref mut table) = metadata {
+            table.insert("permalink".to_string(), toml::Value::String(permalink));
+            table.insert("raw".to_string(), toml::Value::String(html));
+        }
+        posts.push(metadata);
+    }
+
+    posts.sort_by(|a, b| {
+        let a_date = a.get("date").and_then(|v| v.as_str()).unwrap_or_default();
+        let b_date = b.get("date").and_then(|v| v.as_str()).unwrap_or_default();
+
+        let parse_date = |s: &str| {
+            chrono::DateTime::parse_from_str(s, "%Y-%m-%d")
+                .unwrap_or_else(|_| chrono::DateTime::from_timestamp(0, 0).unwrap().into())
+                .with_timezone(&chrono::Utc)
+        };
+
+        parse_date(b_date).cmp(&parse_date(a_date))
+    });
+
+    Ok(posts)
 }

--- a/src/tera_functions.rs
+++ b/src/tera_functions.rs
@@ -1,5 +1,6 @@
-use eyre::Result;
 use std::collections::HashMap;
+
+use eyre::Result;
 use tera::{Error, Function, Value};
 
 /// Now function


### PR DESCRIPTION
This commit adds the possibility to expose all content files at `my-site/posts/` which are then accessible inside the templates allowing for some niceties like creating a Recent posts list template.

It does expose a `posts` array as part of the templates context, which holds the metadata from all the blog posts including an extra `permalink` field and also a `raw` field with the HTML code for the post.