### PR TITLE
feat: expose posts pages to both server and build

### DIFF
--- a/src/tera_functions.rs
+++ b/src/tera_functions.rs
@@ -1,5 +1,6 @@
-use eyre::Result;
 use std::collections::HashMap;
+
+use eyre::Result;
 use tera::{Error, Function, Value};
 
 /// Now function


### PR DESCRIPTION
This commit adds the possibility to expose all content files at `my-site/posts/` which are then accessible inside the templates allowing for some niceties like creating a Recent posts list template.

It does expose a `posts` array as part of the templates context, which holds the metadata from all the blog posts including an extra `permalink` field and also a `raw` field with the HTML code for the post.

---

Follow-up PR for #85 because I've forgotten to create a new commit on jujutsu and now the commit history is fucked up.