### PR TITLE
feat: add support for RSS feeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "atom_syndication"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f68d23e2cb4fd958c705b91a6b4c80ceeaf27a9e11651272a8389d5ce1a4a3"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "diligent-date-parser",
+ "never",
+ "quick-xml",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +283,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -545,6 +559,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +619,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193"
 dependencies = [
  "matches",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -607,6 +687,15 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "diligent-date-parser"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ede7d79366f419921e2e2f67889c12125726692a313bffb474bd5f37a581e9"
+dependencies = [
+ "chrono",
 ]
 
 [[package]]
@@ -652,6 +741,15 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "equivalent"
@@ -1186,6 +1284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1812,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "never"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96aba5aa877601bb3f6dd6a63a969e1f82e60646e81e71b14496995e9853c91"
+
+[[package]]
 name = "newline-converter"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +1862,7 @@ dependencies = [
  "num_cpus",
  "open",
  "regex",
+ "rss",
  "rust-norg",
  "semver",
  "serde",
@@ -2193,6 +2304,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+dependencies = [
+ "encoding_rs",
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,6 +2467,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rss"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2107738f003660f0a91f56fd3e3bd3ab5d918b2ddaf1e1ec2136fb1c46f71bf"
+dependencies = [
+ "atom_syndication",
+ "derive_builder",
+ "never",
+ "quick-xml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "lith"
 path = "src/main.rs"
 
 [dependencies]
-chrono = "0.4.39"
+chrono = { version = "0.4.39", features = ["serde"] }
 clap = { version = "4.5.27", features = ["deprecated", "derive", "env", "wrap_help"] }
 comfy-table = "7.1.3"
 eyre = "0.6.12"
@@ -52,6 +52,7 @@ tracing-subscriber = { version = "0.3.19", features = ["ansi", "chrono", "env-fi
 colored = "3.0.0"
 local-ip-address = "0.6.3"
 titlecase = "3.3.0"
+rss = "2.0.12"
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,13 @@ pub struct SiteConfigHighlighter {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct SiteConfigRss {
+    pub enable: bool,
+    pub ttl: i32,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SiteConfig {
     #[serde(rename = "rootUrl")]
     pub root_url: String,
@@ -20,5 +27,6 @@ pub struct SiteConfig {
     #[serde(default)]
     pub content_schema: Option<ContentSchema>,
     pub highlighter: Option<SiteConfigHighlighter>,
+    pub rss: Option<SiteConfigRss>,
     pub extra: Option<HashMap<String, toml::Value>>,
 }

--- a/src/resources/templates/rss.xml
+++ b/src/resources/templates/rss.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ config.title }}</title>
+    <link>{{ config.rootUrl | escape_xml | safe }}</link>
+    <description>{{ config.rss.description | default(value="Latest posts")}}</description>
+    <generator>Norgolith</generator>
+    <language>{{ config.language }}</language>
+    <lastBuildDate>{{ now | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
+    <ttl>{{ config.rss.ttl | default(value=60) }}</ttl>
+    <atom:link href="{{ config.rootUrl }}/rss.xml" rel="self" type="application/rss+xml" />
+
+    {% for post in posts | filter(attribute="draft", value=false) %}
+    <item>
+      <title>{{ post.title }}</title>
+      <link>{{ post.permalink | escape_xml | safe }}</link>
+      <guid>{{ post.permalink | escape_xml | safe }}</guid>
+      <description>{{ post.description }}</description>
+      <author>{{ post.authors | join(sep=", ") }}</author>
+      <pubDate>{{ post.created | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
+      {% if post.categories %}{% for category in post.categories %}<category>{{ category }}</category>{% endfor %}{% endif %}
+    </item>
+    {% endfor %}
+  </channel>
+</rss>

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -200,10 +200,18 @@ pub async fn init_tera(templates_dir: &str, theme_templates_dir: &Path) -> Resul
     let mut tera = match Tera::parse(&(templates_dir.to_owned() + "/**/*.html")) {
         Ok(t) => t,
         Err(e) => bail!(
-            "Error parsing templates from the templates directory: {}",
+            "Error parsing HTML templates from the templates directory: {}",
             e
         ),
     };
+    let tera_xml = match Tera::parse(&(templates_dir.to_owned() + "/**/*.xml")) {
+        Ok(t) => t,
+        Err(e) => bail!(
+            "Error parsing XML templates from the templates directory: {}",
+            e
+        ),
+    };
+    tera.extend(&tera_xml)?;
 
     // Theme templates will override the user-defined templates by design if they are named exactly
     // the same in both the user's templates directory and the theme templates directory
@@ -211,7 +219,7 @@ pub async fn init_tera(templates_dir: &str, theme_templates_dir: &Path) -> Resul
         let tera_theme =
             match Tera::parse(&(theme_templates_dir.display().to_string() + "/**/*.html")) {
                 Ok(t) => t,
-                Err(e) => bail!("Error parsing templates from themes: {}", e),
+                Err(e) => bail!("Error parsing HTML templates from themes: {}", e),
             };
         tera.extend(&tera_theme)?;
     }


### PR DESCRIPTION
RSS is enabled by default. The default [ttl](https://www.rssboard.org/rss-specification#ltttlgtSubelementOfLtchannelgt) value is `60`.

Configuration options (and their defaults):
```toml
# RSS feed
[rss]
enable = true
description = 'Latest posts'
ttl = 60
```

There is a default modifiable template for RSS in `templates/rss.xml` when creating a new site. Adapting an existing site for using RSS is as simple as creating the file and pasting the defaults:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
  <channel>
    <title>{{ config.title }}</title>
    <link>{{ config.rootUrl | escape_xml | safe }}</link>
    <description>{{ config.rss.description | default(value="Latest posts")}}</description>
    <generator>Norgolith</generator>
    <language>{{ config.language }}</language>
    <lastBuildDate>{{ now | date(format="%a, %d %b %Y %H:%M:%S %z") }}</lastBuildDate>
    <ttl>{{ config.rss.ttl | default(value=60) }}</ttl>
    <atom:link href="{{ config.rootUrl }}/rss.xml" rel="self" type="application/rss+xml" />

    {% for post in posts | filter(attribute="draft", value=false) %}
    <item>
      <title>{{ post.title }}</title>
      <link>{{ post.permalink | escape_xml | safe }}</link>
      <guid>{{ post.permalink | escape_xml | safe }}</guid>
      <description>{{ post.description }}</description>
      <author>{{ post.authors | join(sep=", ") }}</author>
      <pubDate>{{ post.created | date(format="%a, %d %b %Y %H:%M:%S %z") }}</pubDate>
      {% if post.categories %}{% for category in post.categories %}<category>{{ category }}</category>{% endfor %}{% endif %}
    </item>
    {% endfor %}
  </channel>
</rss>
```

---

Closes #62