### PR TITLE
feat: implement taxonomies using `categories`

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -668,11 +668,19 @@ pub async fn build(minify: bool) -> Result<()> {
         )
         .await?;
 
+        // Generate category pages
+        let posts = shared::collect_all_posts_metadata(&paths.build, &site_config.root_url).await?;
+        shared::generate_category_pages(
+            &tera,
+            &paths.public,
+            &posts,
+            &site_config
+        ).await?;
+
         // Generate RSS feed after building content if enabled
         if site_config.rss.clone().is_some_and(|rss| rss.enable) {
             debug!("Generating RSS feed");
             let rss_path = paths.public.join("rss.xml");
-            let posts = shared::collect_all_posts_metadata(&paths.build, &site_config.root_url).await?;
             generate_rss_feed(&tera, &site_config, &posts, &rss_path).await?;
         }
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -88,6 +88,14 @@ async fn create_html_templates(root: &str) -> Result<()> {
             "default",
             include_str!("../resources/templates/default.html"),
         ),
+        (
+            "category",
+            include_str!("../resources/templates/category.html"),
+        ),
+        (
+            "categories",
+            include_str!("../resources/templates/categories.html"),
+        ),
     ]);
 
     let templates_dir = PathBuf::from(root).join("templates");

--- a/src/resources/templates/categories.html
+++ b/src/resources/templates/categories.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+{% block title %}Categories{% endblock title %}
+{% block content %}
+<div>
+  <h1>Categories</h1>
+  <p><i>All the categories used in posts.</i></p>
+  <hr />
+  <ul>
+    {% for category in categories | sort %}
+      {%- set_global cat_posts = 0 -%}
+      {% for post in posts %}
+        {% if category in post.categories %}
+          {%- set_global cat_posts = cat_posts + 1 -%}
+        {% endif %}
+      {% endfor %}
+      <li>
+        <a href="{{ config.rootUrl }}/categories/{{ category }}">{{ category }}</a>
+        <span>({{ cat_posts }} post{{ cat_posts | pluralize }})</span>
+      </li>
+    {% endfor %}
+  </ul>
+</div>
+{% endblock content %}

--- a/src/resources/templates/category.html
+++ b/src/resources/templates/category.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block title %}Category: {{ category }}{% endblock title %}
+{% block content %}
+<div>
+  <h1>Posts in {{ category }}</h1>
+  <p><i>All the posts with the category "{{ category }}"</i></p>
+  <hr />
+  <ul>
+    {% for post in posts %}
+      {% if category in post.categories %}
+        <li>
+          <a href="{{ post.permalink }}">{{ post.title }}</a>
+          <time>{{ post.created | date(format="%B %e, %Y") }}</time>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+</div>
+{% endblock content %}


### PR DESCRIPTION
Default templates for `category.html` and `categories.html` are generated on `lith init`, existing sites can grab them from [src/resources/templates](https://github.com/NTBBloodbath/norgolith/tree/master/src/resources/templates).

There are two new special routes, `/categories` and `/categories/[category]` which should be automatically generated on both `build` or `serve`.