### PR TITLE
feat(config): allow setting commands configuration in the site configuration file

### DIFF
--- a/src/config/commands.rs
+++ b/src/config/commands.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct BuildConfig {
+    #[serde(default = "default_minify")]
+    pub minify: bool,
+}
+
+fn default_minify() -> bool { true }
+
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+pub struct ServeConfig {
+    #[serde(default = "default_port")]
+    pub port: u16,
+    #[serde(default = "default_drafts")]
+    pub drafts: bool,
+    #[serde(default)]
+    pub host: bool,
+    #[serde(default)]
+    pub open: bool,
+}
+
+fn default_port() -> u16 { 3030 }
+fn default_drafts() -> bool { true }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -3,6 +3,9 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::schema::ContentSchema;
+use commands::{BuildConfig, ServeConfig};
+
+pub mod commands;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SiteConfigHighlighter {
@@ -18,13 +21,17 @@ pub struct SiteConfigRss {
     pub image: String,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Default, Debug, Clone, Deserialize, Serialize)]
 pub struct SiteConfig {
     #[serde(rename = "rootUrl")]
     pub root_url: String,
     pub language: String,
     pub title: String,
     pub author: String,
+    #[serde(default)]
+    pub build: Option<BuildConfig>,
+    #[serde(default)]
+    pub serve: Option<ServeConfig>,
     #[serde(default)]
     pub content_schema: Option<ContentSchema>,
     pub highlighter: Option<SiteConfigHighlighter>,


### PR DESCRIPTION
Allows setting commands configuration directly in the `norgolith.toml`.

E.g.
```toml
[serve]
port = 8080 # Use 8080 as the default instead of 3030
open = true # Automatically open the web browser page
host = true # Expose server to LAN

[build]
minify = false # Do not minify artifacts
```

Closes #83