### PR TITLE
Fix: enable vendored git2 features for every targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ num_cpus = "1.16.0"
 minify-js = "0.6.0"
 regex = "1.11.1"
 semver = { version = "1.0.25", features = ["serde"] }
-git2 = "0.20.0"
+git2 = { version = "0.20.0", features = ["vendored-libgit2", "vendored-openssl"] }
 tempfile = "3.17.1"
 inquire = { version = "0.7.5", features = ["chrono", "date"] }
 spinoff = "0.8.0"
@@ -53,12 +53,6 @@ local-ip-address = "0.6.3"
 titlecase = "3.3.0"
 rss = "2.0.12"
 lightningcss = "1.0.0-alpha.64"
-
-[target.aarch64-unknown-linux-musl.dependencies]
-git2 = { version = "0.20.0", features = ["vendored-libgit2", "vendored-openssl"] }
-
-[target.x86_64-unknown-linux-musl.dependencies]
-git2 = { version = "0.20.0", features = ["vendored-libgit2", "vendored-openssl"] }
 
 [dev-dependencies]
 mockall = "0.13.1"


### PR DESCRIPTION
I setup fresh machine and found that I couldn't build the norgolith due to unincluded dependencies.
So include `vendored` features in `git2` for all targets by default.