### PR TITLE
fix: add perl to nativeBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
 
           nativeBuildInputs = with pkgs; [
             pkg-config
+            perl
           ];
           buildInputs = with pkgs; [
             openssl


### PR DESCRIPTION
It is failing to build OpenSSL otherwise using `nix build`