### PR TITLE
fix(build): ignore draft posts on category page

### DIFF
--- a/src/cmd/dev.rs
+++ b/src/cmd/dev.rs
@@ -1004,7 +1004,7 @@ async fn setup_file_watcher(
 ///
 /// # Arguments
 /// * `port` - The port on which the server will run.
-/// * `drafts` - Whether to build draft content.
+/// * `drafts` - Whether to serve draft content.
 /// * `open` - Whether to open the site in the browser after starting the server.
 ///
 /// # Returns


### PR DESCRIPTION
Fixes issue mentioned in discord server by @Ladas552 https://discordapp.com/channels/834325286664929280/1272657884743860235/1377461059992027156

Now `build` subcommand will always ignore all draft posts in category page.
I'm considering to add `--drafts` option in `build` command too, but that will come after #117 is fixed