### PR TITLE
docs(readme): add AUR package instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,15 @@ Options:
 
 Run `cargo install --release --path .` to compile and install Norgolith in your `~/.cargo/bin` directory.
 
+### 🔨 AUR
+
+Use Arch User Repository helper to install `norgolith-git`.
+
+`paru -S norgolith-git`
+
 ### 📦 Nix Package
 
-You can add norgolith to your NixOS configuration with flakes
+You can add norgolith to your NixOS configuration with flakes.
 
 <details>
 <summary>Minimal flake.nix for a NixOS configuration:</summary>


### PR DESCRIPTION
Add AUR instructions into the Readme.md and add a period at the end to 2 sentences

references issue: https://github.com/NTBBloodbath/norgolith/issues/119

Please add instructions to the Docs website branch too, I don't have access to it.

