### PR TITLE
feat: auto-discover and render all XML templates as feeds

### DIFF
--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -10,7 +10,7 @@ use lightningcss::stylesheet::{MinifyOptions, ParserOptions, PrinterOptions, Sty
 use rss::Channel;
 use tera::{Context, Tera};
 use tokio::sync::Mutex;
-use tracing::{debug, error, instrument};
+use tracing::{debug, error, instrument, warn};
 use walkdir::WalkDir;
 
 use crate::{config, fs, shared};
@@ -116,30 +116,68 @@ async fn prepare_build_directory(public_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-#[instrument(level = "debug", skip(tera, site_config, posts, output_path))]
-async fn generate_rss_feed(
+/// Collects the names of all XML templates registered in the Tera instance.
+fn collect_xml_templates(tera: &Tera) -> Vec<String> {
+    tera.get_template_names()
+        .filter(|name| name.ends_with(".xml"))
+        .map(|name| name.to_string())
+        .collect()
+}
+
+/// Renders all XML feed templates and writes them to the public directory.
+///
+/// Each XML template found in the Tera instance is rendered with site and post
+/// context, then written to the corresponding path under `public_dir`.
+/// Subdirectories are created as needed. RSS validation is attempted per file;
+/// failures emit a warning rather than aborting, so non-RSS formats (Atom,
+/// sitemaps, etc.) are also supported.
+#[instrument(level = "debug", skip(tera, site_config, posts, public_dir))]
+async fn generate_xml_feeds(
     tera: &Tera,
     site_config: &config::SiteConfig,
     posts: &[toml::Value],
-    output_path: &Path,
-) -> Result<()> {
-    // Prepare template
+    public_dir: &Path,
+) -> Result<usize> {
+    let xml_templates = collect_xml_templates(tera);
+    let count = xml_templates.len();
+    if count == 0 {
+        return Ok(0);
+    }
+
     let mut context = Context::new();
     context.insert("config", site_config);
     context.insert("posts", posts);
     context.insert("now", &chrono::Utc::now());
 
-    // Render the template
-    let rss_content = tera
-        .render("rss.xml", &context)
-        .map_err(|e| eyre!("{}: {}", "Failed to render RSS template".bold(), e))?;
+    for template_name in &xml_templates {
+        let rendered = tera
+            .render(template_name, &context)
+            .map_err(|e| eyre!("{}: {}", "Failed to render XML template".bold(), e))?;
 
-    // Parse the rendered XML to validate it
-    Channel::read_from(rss_content.as_bytes())
-        .map_err(|e| eyre!("{}: {}", "Invalid RSS feed generated".bold(), e))?;
+        if let Err(e) = Channel::read_from(rendered.as_bytes()) {
+            warn!(
+                template = %template_name,
+                "'{}' does not validate as RSS ({}); written as-is",
+                template_name,
+                e
+            );
+        }
 
-    tokio::fs::write(output_path, rss_content).await?;
-    Ok(())
+        let output_path = public_dir.join(template_name);
+        if let Some(parent) = output_path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .wrap_err(format!(
+                    "Failed to create output directory for '{}'",
+                    template_name
+                ))?;
+        }
+        tokio::fs::write(&output_path, &rendered)
+            .await
+            .wrap_err(format!("Failed to write '{}'", output_path.display()))?;
+    }
+
+    Ok(count)
 }
 
 /// Generates the final public build from intermediate build artifacts
@@ -675,17 +713,15 @@ pub async fn build(minify: bool) -> Result<()> {
         );
     }
 
-    // Generate RSS feed after building content if enabled
-    if site_config.rss.as_ref().is_some_and(|rss| rss.enable) {
-        debug!("Generating RSS feed");
-        let step_start = std::time::Instant::now();
-        let rss_path = paths.public.join("rss.xml");
-        generate_rss_feed(&tera, &site_config, &posts, &rss_path).await?;
+    // Generate XML feeds (RSS, Atom, sitemaps, etc.) from all XML templates
+    let step_start = std::time::Instant::now();
+    let feed_count = generate_xml_feeds(&tera, &site_config, &posts, &paths.public).await?;
+    if feed_count > 0 {
         println!(
             "  {} {}  {:<12}  {}",
             "•".green(),
-            format!("{:<12}", "RSS").bold(),
-            "1 file",
+            format!("{:<12}", "Feeds").bold(),
+            format!("{} files", feed_count),
             shared::get_elapsed_time(step_start).dimmed()
         );
     }

--- a/src/cmd/dev.rs
+++ b/src/cmd/dev.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::Utc;
 use colored::Colorize;
 use eyre::{bail, eyre, Result};
 use futures_util::{SinkExt, Stream, StreamExt};
@@ -203,7 +204,7 @@ async fn is_template_change(event: &notify::Event) -> bool {
     let Some(path) = event.paths.first() else {
         return false;
     };
-    let is_template = path.extension().is_some_and(|ext| ext == "html");
+    let is_template = path.extension().is_some_and(|ext| ext == "html" || ext == "xml");
     let Some(parent_dir) = path.parent() else {
         return false;
     };
@@ -587,6 +588,36 @@ async fn resolve_url_norg_path(content_dir: &Path, path: &Path) -> std::io::Resu
 /// # Returns
 /// * `Result<Response<Body>>` - A `Response` containing the content or an error if the
 ///   content cannot be retrieved or rendered.
+/// Renders an XML feed template for the requested path.
+///
+/// Strips the leading `/` from the request path to derive the template name
+/// (e.g. `/rss.xml` → `rss.xml`, `/en/rss.xml` → `en/rss.xml`). Returns 404
+/// if no matching XML template is registered.
+async fn handle_xml_feed(request_path: &str, state: &Arc<ServerState>) -> Result<Response<Body>> {
+    let template_name = request_path.trim_start_matches('/');
+    debug!(template = %template_name, "Handling XML feed request");
+
+    let tera = state.tera.read().await;
+    if !tera.get_template_names().any(|n| n == template_name) {
+        return Ok(handle_not_found());
+    }
+
+    let posts = state.posts.read().await.clone();
+    let mut context = Context::new();
+    context.insert("config", &state.config);
+    context.insert("posts", &posts);
+    context.insert("now", &Utc::now());
+
+    let content = tera
+        .render(template_name, &context)
+        .map_err(|e| eyre!("{}: {}", "Failed to render XML feed template".bold(), e))?;
+
+    Ok(Response::builder()
+        .header(CONTENT_TYPE, "application/xml; charset=utf-8")
+        .status(StatusCode::OK)
+        .body(Body::from(content))?)
+}
+
 async fn handle_content(request_path: &str, state: Arc<ServerState>) -> Result<Response<Body>> {
     let req_path = PathBuf::from(request_path.trim_start_matches('/'));
     debug!(?req_path);
@@ -809,6 +840,7 @@ async fn handle_request(req: Request<Body>, state: Arc<ServerState>) -> Result<R
         "/categories" => handle_category_index(&state).await,
         path if path.starts_with("/categories/") => handle_category(path, &state).await,
         path if path.starts_with("/assets/") => handle_asset(path, &state.paths).await,
+        path if path.ends_with(".xml") => handle_xml_feed(path, &state).await,
         _ => handle_content(request_path, state).await,
     }
 }


### PR DESCRIPTION
Replace the hardcoded rss.xml generation with a convention-based approach: every *.xml file in templates/ is rendered and written to the corresponding path in public/. Subdirectories are created as needed, enabling paths like /en/rss.xml or /feed.xml without any configuration changes.

RSS validation is kept but demoted to a warning so non-RSS formats (Atom, sitemaps) are also supported. The dev server now serves all XML templates and hot-reloads when they change.

See #111