### PR TITLE
feat: add configurable content collections and categoriesDir

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -105,13 +105,21 @@ enum Commands {
             value_parser = [
                 PossibleValue::new("norg").help("New norg file"),
                 PossibleValue::new("css").help("New CSS stylesheet"),
-                PossibleValue::new("js").help("New JS script")
+                PossibleValue::new("js").help("New JS script"),
+                PossibleValue::new("post").help("New post in a configured collection")
             ]
         )]
         kind: Option<String>,
 
         /// Asset name, e.g. 'post1.norg' or 'hello.js'
         name: Option<String>,
+
+        #[arg(
+            short = 'c',
+            long = "collection",
+            help = "Target collection name (only used with --kind post)"
+        )]
+        collection: Option<String>,
     },
     /// Build a site for production
     Build {
@@ -180,7 +188,7 @@ pub async fn start() -> Result<()> {
             minify: _,
             _no_minify,
         } => build_site(!_no_minify).await?,
-        Commands::New { kind, name, open } => new_asset(kind.as_ref(), name.as_ref(), open).await?,
+        Commands::New { kind, name, open, collection } => new_asset(kind.as_ref(), name.as_ref(), open, collection.as_ref()).await?,
         Commands::Preview { port, host, open } => preview(port, open, host).await?,
     }
 
@@ -268,21 +276,15 @@ async fn theme_handle(subcommand: &cmd::ThemeCommands) -> Result<()> {
 /// Ok(())
 /// }
 /// ```
-async fn new_asset(kind: Option<&String>, name: Option<&String>, open: bool) -> Result<()> {
-    let asset_type = kind.unwrap_or(&String::from("content")).to_owned();
+async fn new_asset(kind: Option<&String>, name: Option<&String>, open: bool, collection: Option<&String>) -> Result<()> {
+    let asset_type = kind.unwrap_or(&String::from("norg")).to_owned();
 
-    if ![
-        String::from("js"),
-        String::from("css"),
-        String::from("norg"),
-    ]
-    .contains(&asset_type)
-    {
+    if !["js", "css", "norg", "post"].contains(&asset_type.as_str()) {
         bail!("Unable to create site asset: unknown asset type provided");
     }
 
     match name {
-        Some(name) => cmd::new(&asset_type, name, open).await,
+        Some(name) => cmd::new(&asset_type, name, open, collection).await,
         None => bail!("Unable to create site asset: missing name for the asset"),
     }
 }

--- a/src/cmd/build.rs
+++ b/src/cmd/build.rs
@@ -147,6 +147,7 @@ async fn generate_xml_feeds(
     let mut context = Context::new();
     context.insert("config", site_config);
     context.insert("posts", posts);
+    shared::insert_collection_subsets(&mut context, posts, site_config);
     context.insert("now", &chrono::Utc::now());
 
     for template_name in &xml_templates {
@@ -246,6 +247,7 @@ async fn build_contents(
 ///
 /// Handles template rendering, metadata validation, and output path determination.
 /// Skips draft content and applies minification when enabled.
+#[allow(clippy::too_many_arguments)]
 #[instrument(
     level = "debug",
     skip(tera, paths, site_config, validation_errors, built_count, posts)
@@ -277,7 +279,7 @@ async fn build_content_entry(
     // Metadata schema validation
     if let Some(schema) = &site_config.content_schema {
         // Do not try to validate generated categories
-        if !rel_path.starts_with("categories") {
+        if !rel_path.starts_with(&site_config.categories_dir) {
             let errors =
                 shared::validate_content_metadata(&paths.content, path, &metadata, schema, false)
                     .await?;
@@ -327,7 +329,7 @@ pub async fn build_category_pages(
     config: &config::SiteConfig,
 ) -> Result<usize> {
     let categories = shared::collect_all_posts_categories(posts).await;
-    let categories_dir = public_dir.join("categories");
+    let categories_dir = public_dir.join(&config.categories_dir);
 
     // Generate category pages only if the site has posts
     if posts.is_empty() {
@@ -673,8 +675,9 @@ pub async fn build(minify: bool) -> Result<()> {
     // Prepare the public build directory
     prepare_build_directory(&paths.public).await?;
 
-    let posts: Vec<_> = shared::collect_all_posts_metadata(&paths.content, &site_config.root_url)
-        .await?
+    let posts: Vec<_> =
+        shared::collect_all_posts_metadata(&paths.content, &site_config.root_url, &site_config.collections)
+            .await?
         .into_iter()
         .filter(|post| {
             !post

--- a/src/cmd/dev.rs
+++ b/src/cmd/dev.rs
@@ -334,7 +334,7 @@ async fn execute_actions(actions: FileActions, state: Arc<ServerState>) {
     }
 
     if actions.reload_content {
-        match shared::collect_all_posts_metadata(&state.paths.content, &state.routes_url).await {
+        match shared::collect_all_posts_metadata(&state.paths.content, &state.routes_url, &state.config.collections).await {
             Ok(new_posts) => {
                 let mut posts_lock = state.posts.write().await;
                 *posts_lock = new_posts;
@@ -575,19 +575,6 @@ async fn resolve_url_norg_path(content_dir: &Path, path: &Path) -> std::io::Resu
     Ok(path)
 }
 
-/// Handles requests for content, either static or dynamic.
-///
-/// This function serves content from the content directory. If the content is a static file
-/// (e.g., an image), it serves it directly. Otherwise, it renders the content as HTML
-/// using Tera templates.
-///
-/// # Arguments
-/// * `request_path` - The path of the requested content.
-/// * `state` - The shared server state.
-///
-/// # Returns
-/// * `Result<Response<Body>>` - A `Response` containing the content or an error if the
-///   content cannot be retrieved or rendered.
 /// Renders an XML feed template for the requested path.
 ///
 /// Strips the leading `/` from the request path to derive the template name
@@ -606,6 +593,7 @@ async fn handle_xml_feed(request_path: &str, state: &Arc<ServerState>) -> Result
     let mut context = Context::new();
     context.insert("config", &state.config);
     context.insert("posts", &posts);
+    shared::insert_collection_subsets(&mut context, &posts, &state.config);
     context.insert("now", &Utc::now());
 
     let content = tera
@@ -618,6 +606,11 @@ async fn handle_xml_feed(request_path: &str, state: &Arc<ServerState>) -> Result
         .body(Body::from(content))?)
 }
 
+/// Handles requests for content, either static or dynamic.
+///
+/// Serves content from the content directory. If the content is a static file
+/// (e.g., an image), it serves it directly. Otherwise, it renders the content as HTML
+/// using Tera templates.
 async fn handle_content(request_path: &str, state: Arc<ServerState>) -> Result<Response<Body>> {
     let req_path = PathBuf::from(request_path.trim_start_matches('/'));
     debug!(?req_path);
@@ -741,6 +734,7 @@ async fn handle_category_index(state: &Arc<ServerState>) -> Result<Response<Body
     let mut context = Context::new();
     context.insert("config", &state.config);
     context.insert("posts", &posts);
+    shared::insert_collection_subsets(&mut context, &posts, &state.config);
     context.insert("categories", &categories.into_iter().collect::<Vec<_>>());
 
     let tera = state.tera.read().await;
@@ -771,7 +765,8 @@ async fn handle_category_index(state: &Arc<ServerState>) -> Result<Response<Body
 }
 
 async fn handle_category(path: &str, state: &Arc<ServerState>) -> Result<Response<Body>> {
-    let category = path.trim_start_matches("/categories/");
+    let cat_prefix = format!("/{}/", state.config.categories_dir);
+    let category = path.strip_prefix(&*cat_prefix).unwrap_or(path);
     let posts = state.posts.read().await.clone();
 
     let category_posts: Vec<_> = posts
@@ -837,8 +832,8 @@ async fn handle_request(req: Request<Body>, state: Arc<ServerState>) -> Result<R
         "/livereload.js" => Ok(Response::builder()
             .header(CONTENT_TYPE, "text/javascript")
             .body(LIVE_RELOAD_SCRIPT.into())?),
-        "/categories" => handle_category_index(&state).await,
-        path if path.starts_with("/categories/") => handle_category(path, &state).await,
+        path if path == format!("/{}", state.config.categories_dir) => handle_category_index(&state).await,
+        path if path.starts_with(&format!("/{}/", state.config.categories_dir)) => handle_category(path, &state).await,
         path if path.starts_with("/assets/") => handle_asset(path, &state.paths).await,
         path if path.ends_with(".xml") => handle_xml_feed(path, &state).await,
         _ => handle_content(request_path, state).await,
@@ -969,7 +964,7 @@ async fn setup_server_state(
 
     let (reload_tx, _) = broadcast::channel(16);
 
-    let posts = shared::collect_all_posts_metadata(&paths.content, &routes_url).await?;
+    let posts = shared::collect_all_posts_metadata(&paths.content, &routes_url, &site_config.collections).await?;
 
     Ok(Arc::new(ServerState {
         reload_tx: Arc::new(reload_tx),

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -35,7 +35,16 @@ async fn create_config(root: &str, root_url: &str, language: &str, title: &str) 
         enable = true
         description = 'Latest posts'
         ttl = 60
-        image = '/assets/favicon.png'"#,
+        image = '/assets/favicon.png'
+
+        # Content collections (posts source dirs and URL prefixes)
+        # Defaults to a single "posts" collection if not set
+        # [[collections]]
+        # name = "posts"
+        # dir  = "posts"
+
+        # URL prefix for generated category pages (default: "categories")
+        # categoriesDir = "categories""#,
         root_url, // this is the default port
         language,
         title,

--- a/src/cmd/new.rs
+++ b/src/cmd/new.rs
@@ -7,13 +7,13 @@ use chrono::{Local, SecondsFormat};
 use colored::Colorize;
 use eyre::{bail, eyre, Context, Result};
 use indoc::formatdoc;
-use inquire::Text;
+use inquire::{Select, Text};
 use regex::Regex;
 use titlecase::titlecase;
 use tracing::{debug, info, instrument, warn};
 use whoami::username;
 
-use crate::fs;
+use crate::{config, fs};
 
 /// Supported asset types for creation
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -215,14 +215,72 @@ async fn open_file_editor(path: &Path) -> Result<()> {
     Ok(())
 }
 
-#[instrument(skip(kind, name, open))]
-pub async fn new(kind: &str, name: &str, open: bool) -> Result<()> {
+fn resolve_collection<'a>(
+    collections: &'a [config::CollectionConfig],
+    collection_name: Option<&String>,
+) -> Result<&'a config::CollectionConfig> {
+    if collections.is_empty() {
+        bail!("No collections configured. Add [[collections]] to norgolith.toml");
+    }
+    if let Some(name) = collection_name {
+        collections
+            .iter()
+            .find(|c| c.name == *name)
+            .ok_or_else(|| {
+                let available = collections
+                    .iter()
+                    .map(|c| c.name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                eyre!("Unknown collection '{}'. Available: {}", name, available)
+            })
+    } else if collections.len() == 1 {
+        Ok(&collections[0])
+    } else {
+        let names: Vec<&str> = collections.iter().map(|c| c.name.as_str()).collect();
+        let selected_name = Select::new("Select a collection:", names)
+            .prompt()
+            .map_err(|e| eyre!("Failed to select collection: {}", e))?;
+        Ok(collections
+            .iter()
+            .find(|c| c.name == selected_name)
+            .unwrap())
+    }
+}
+
+#[instrument(skip(kind, name, open, collection))]
+pub async fn new(kind: &str, name: &str, open: bool, collection: Option<&String>) -> Result<()> {
     debug!(type = kind, name = name, "Creating new asset");
-    let asset_type = AssetType::from_extension(kind)?;
-    let mut input_path = PathBuf::from(name);
+
+    // Find site root early — needed for "post" collection resolution
+    let config_file = fs::find_config_file().await?.ok_or_else(|| {
+        eyre!(
+            "{}: not in a Norgolith site directory",
+            "Unable to create site asset".bold()
+        )
+    })?;
+    let site_root = config_file.parent().unwrap().to_path_buf();
+
+    // "post" kind: resolve the target collection and delegate to Content creation
+    let (resolved_kind, resolved_name);
+    if kind == "post" {
+        let config_content = tokio::fs::read_to_string(&config_file)
+            .await
+            .map_err(|e| eyre!("Failed to read config: {}", e))?;
+        let site_config: config::SiteConfig =
+            toml::from_str(&config_content).map_err(|e| eyre!("Failed to parse config: {}", e))?;
+        let col = resolve_collection(&site_config.collections, collection)?;
+        resolved_kind = "norg".to_string();
+        resolved_name = format!("{}/{}", col.dir, name);
+    } else {
+        resolved_kind = kind.to_string();
+        resolved_name = name.to_string();
+    }
+
+    let asset_type = AssetType::from_extension(&resolved_kind)?;
+    let mut input_path = PathBuf::from(&resolved_name);
 
     // Validate file extension
-    // TODO: also validate assets?
     if let AssetType::Content = asset_type {
         // Add norg file extension to content name if it is missing an extension
         if input_path.extension().is_none() {
@@ -233,16 +291,6 @@ pub async fn new(kind: &str, name: &str, open: bool) -> Result<()> {
             bail!("Norg documents must have .norg extension");
         }
     }
-
-    // Find site root
-    let mut site_root = fs::find_config_file().await?.ok_or_else(|| {
-        eyre!(
-            "{}: not in a Norgolith site directory",
-            "Unable to create site asset".bold()
-        )
-    })?;
-    // Remove norgolith.toml from the site_root
-    site_root.pop();
 
     // Build target path
     let mut target_path = site_root.join(asset_type.directory());

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,7 +18,24 @@ pub struct SiteConfigRss {
     pub image: String,
 }
 
-#[derive(Default, Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CollectionConfig {
+    pub name: String,
+    pub dir: String,
+}
+
+fn default_collections() -> Vec<CollectionConfig> {
+    vec![CollectionConfig {
+        name: "posts".into(),
+        dir: "posts".into(),
+    }]
+}
+
+fn default_categories_dir() -> String {
+    "categories".into()
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct SiteConfig {
     #[serde(rename = "rootUrl")]
     pub root_url: String,
@@ -30,4 +47,25 @@ pub struct SiteConfig {
     pub highlighter: Option<SiteConfigHighlighter>,
     pub rss: Option<SiteConfigRss>,
     pub extra: Option<HashMap<String, toml::Value>>,
+    #[serde(default = "default_collections", rename = "collections")]
+    pub collections: Vec<CollectionConfig>,
+    #[serde(default = "default_categories_dir", rename = "categoriesDir")]
+    pub categories_dir: String,
+}
+
+impl Default for SiteConfig {
+    fn default() -> Self {
+        Self {
+            root_url: String::new(),
+            language: String::new(),
+            title: String::new(),
+            author: String::new(),
+            content_schema: None,
+            highlighter: None,
+            rss: None,
+            extra: None,
+            collections: default_collections(),
+            categories_dir: default_categories_dir(),
+        }
+    }
 }

--- a/src/converter/html.rs
+++ b/src/converter/html.rs
@@ -390,7 +390,7 @@ impl NorgToHtml for NorgAST {
             }
             NorgAST::NestableDetachedModifier {
                 modifier_type,
-                level,
+                level: _,
                 text,
                 content,
                 ..

--- a/src/resources/templates/categories.html
+++ b/src/resources/templates/categories.html
@@ -14,7 +14,7 @@
         {% endif %}
       {% endfor %}
       <li>
-        <a href="{{ config.rootUrl }}/categories/{{ category }}">{{ category }}</a>
+        <a href="{{ config.rootUrl }}/{{ config.categoriesDir }}/{{ category }}">{{ category }}</a>
         <span>({{ cat_posts }} post{{ cat_posts | pluralize }})</span>
       </li>
     {% endfor %}

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -9,9 +9,34 @@ use tera::{Context, Tera};
 use tracing::error;
 use walkdir::WalkDir;
 
-use crate::config::SiteConfig;
+use crate::config::{CollectionConfig, SiteConfig};
 use crate::converter;
 use crate::schema::{format_errors, validate_metadata, ContentSchema};
+
+/// Inserts per-collection post subsets into a Tera context.
+///
+/// Filters `all_posts` by permalink prefix for each configured collection and inserts
+/// the result under the collection's `name` key (e.g. `{{ journal }}`, `{{ log }}`).
+/// The combined `posts` variable must be inserted separately before calling this.
+pub fn insert_collection_subsets(
+    context: &mut Context,
+    all_posts: &[toml::Value],
+    config: &SiteConfig,
+) {
+    for collection in &config.collections {
+        let prefix = format!("/{}/", collection.dir);
+        let subset: Vec<_> = all_posts
+            .iter()
+            .filter(|p| {
+                p.get("permalink")
+                    .and_then(|v| v.as_str())
+                    .map(|permalink| permalink.contains(&prefix))
+                    .unwrap_or(false)
+            })
+            .collect();
+        context.insert(&collection.name, &subset);
+    }
+}
 
 /// Render full norg page by converting it to HTML and applying tera template
 pub async fn render_norg_page(
@@ -31,6 +56,7 @@ pub async fn render_norg_page(
     context.insert("content", content);
     context.insert("metadata", metadata);
     context.insert("posts", posts);
+    insert_collection_subsets(&mut context, posts, config);
 
     tera.render(&format!("{}.html", layout), &context)
         .map_err(|e| {
@@ -54,6 +80,7 @@ pub async fn render_category_index(
         let mut ctx = Context::new();
         ctx.insert("config", config);
         ctx.insert("posts", posts);
+        insert_collection_subsets(&mut ctx, posts, config);
         ctx.insert("categories", &categories.iter().collect::<Vec<_>>());
         ctx
     };
@@ -262,6 +289,7 @@ pub async fn collect_all_posts_categories(posts: &[toml::Value]) -> HashSet<Stri
 pub async fn collect_all_posts_metadata(
     content_dir: &Path,
     routes_url: &str,
+    collections: &[CollectionConfig],
 ) -> Result<Vec<toml::Value>> {
     let mut posts = Vec::new();
 
@@ -271,9 +299,12 @@ pub async fn collect_all_posts_metadata(
         .filter(|e| {
             let path = e.path();
             let is_norg_file = path.extension().is_some_and(|ext| ext == "norg");
-            let is_post = path
-                .strip_prefix(content_dir)
-                .is_ok_and(|p| p.starts_with("posts") && p != Path::new("posts/index.norg"));
+            let is_post = path.strip_prefix(content_dir).is_ok_and(|p| {
+                collections.iter().any(|c| {
+                    p.starts_with(&c.dir)
+                        && p != Path::new(&format!("{}/index.norg", c.dir))
+                })
+            });
             is_norg_file && is_post
         })
     {


### PR DESCRIPTION
Theme authors might need custom URL prefixes (e.g. /journal, /log)
instead of the hardcoded /posts dir, and a renamed categories endpoint.

- [[collections]] config replaces hardcoded "posts". Each collection gets its own source dir, output path, URL prefix, and template var
- categoriesDir config replaces hardcoded "categories" route
- lith new post <name> resolves the right collection dir; prompts when multiple collections are configured (--collection to skip prompt)
- Combined {{ posts }} var preserved for backwards compat and RSS feeds
- Defaults to posts/categories behavior, requires zero migration for existing sites

This feature arose from my own immediate need while developing a new theme with different post scopes, and a search for greater flexibility and granularity. I finally put my butt to work on it.

Reference:
https://discord.com/channels/834325286664929280/1272657884743860235/1506773173956251778