### PR TITLE
feat: add MCP server for AI documentation access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,6 +2084,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "norgolith-mcp"
+version = "1.0.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "norgolith-plugin-sdk"
 version = "1.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["core", "sdk"]
+members = ["core", "sdk", "norgolith-mcp"]
 resolver = "2"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ For git version you can add Norgolith to NixOS configuration with flakes.
 ```
 </details>
 
+### 🤖 MCP Server
+
+Norgolith ships an MCP (Model Context Protocol) server for AI assistants to browse, read, and search documentation. Build it from source:
+
+```bash
+cargo build --release -p norgolith-mcp
+```
+
+The binary is at `target/release/norgolith-mcp`. Configure it in your MCP client (opencode example):
+
+```json
+{
+  "mcp": {
+    "norgolith": {
+      "type": "local",
+      "command": "norgolith-mcp",
+      "enable": true
+    }
+  }
+}
+```
+
+See [norgolith-mcp/README.md](./norgolith-mcp/README.md) for details.
+
 ## ❄️ Developing and testing with Nix
 
 The Norgolith repository includes a Nix flake for development and testing purposes in the root directory. This section outlines how to

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,7 @@
         toolchain = pkgs.rustPlatform;
         corePackage = (pkgs.lib.importTOML "${self}/core/Cargo.toml").package;
         sdkPackage = (pkgs.lib.importTOML "${self}/sdk/Cargo.toml").package;
+        mcpPackage = (pkgs.lib.importTOML "${self}/norgolith-mcp/Cargo.toml").package;
       in rec {
         # nix build
         packages.default = toolchain.buildRustPackage {
@@ -85,6 +86,24 @@
             homepage = sdkPackage.repository;
             license = pkgs.lib.licenses.gpl2Only;
             maintainers = sdkPackage.authors;
+          };
+        };
+
+        packages.norgolith-mcp = toolchain.buildRustPackage {
+          pname = mcpPackage.name;
+          version = mcpPackage.version;
+          src = pkgs.lib.cleanSource "${self}";
+          cargoLock = {
+            lockFile = "${self}/Cargo.lock";
+            allowBuiltinFetchGit = true;
+          };
+          cargoBuildFlags = ["-p" "norgolith-mcp"];
+
+          meta = {
+            description = mcpPackage.description;
+            homepage = mcpPackage.repository;
+            license = pkgs.lib.licenses.gpl2Only;
+            maintainers = mcpPackage.authors;
           };
         };
 

--- a/norgolith-mcp/Cargo.toml
+++ b/norgolith-mcp/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "norgolith-mcp"
+version = "1.0.0"
+edition = "2024"
+authors = ["NTBBloodbath <bloodbathalchemist@protonmail.com"]
+license = "GPL-2.0"
+description = "MCP server for Norgolith documentation"
+repository = "https://github.com/norgolith/core"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/norgolith-mcp/README.md
+++ b/norgolith-mcp/README.md
@@ -50,11 +50,22 @@ Each documentation page is available as a resource with URI `norgolith://{path}`
 | `norgolith://docs/theming` | Theming guide |
 | `norgolith://index` | Site landing page |
 
+Source code resources (MIME type `text/x-rust`):
+
+| URI | Description |
+| --- | ----------- |
+| `norgolith://src/sdk/lib.rs` | Plugin SDK API |
+| `norgolith://src/core/plugin/mod.rs` | Plugin loader core |
+| `norgolith://src/core/plugin/ffi.rs` | C ABI bridge |
+| `norgolith://src/core/plugin/manifest.rs` | Plugin manifest parsing |
+| `norgolith://src/core/plugin/sandbox.rs` | Landlock sandboxing |
+
 ## Tools
 
 | Tool | Description |
 |------|-------------|
 | `search_docs(query)` | Search all documentation for a query string |
+| `read_source(path)` | Read a source file from the repo (monorepo only) |
 
 ## See Also
 

--- a/norgolith-mcp/README.md
+++ b/norgolith-mcp/README.md
@@ -59,6 +59,9 @@ Source code resources (MIME type `text/x-rust`):
 | `norgolith://src/core/plugin/ffi.rs` | C ABI bridge |
 | `norgolith://src/core/plugin/manifest.rs` | Plugin manifest parsing |
 | `norgolith://src/core/plugin/sandbox.rs` | Landlock sandboxing |
+| `norgolith://src/core/shared/render.rs` | Tera context variables |
+| `norgolith://src/core/shared/metadata.rs` | Page metadata structure |
+| `norgolith://src/core/tera/mod.rs` | Tera functions, filters, and tests |
 
 ## Tools
 
@@ -66,6 +69,30 @@ Source code resources (MIME type `text/x-rust`):
 |------|-------------|
 | `search_docs(query)` | Search all documentation for a query string |
 | `read_source(path)` | Read a source file from the repo (monorepo only) |
+
+## Prompts
+
+Examples you can ask the AI with this MCP server enabled:
+
+**Plugin development:**
+- "How do I write a Norgolith plugin?"
+- "How does the plugin manifest work?"
+- "What hooks are available and when do they run?"
+- "Show me the plugin SDK source code"
+- "How does the FFI bridge work?"
+
+**Theme development:**
+- "How do I create a Norgolith theme?"
+- "What Tera variables are available in templates?"
+- "Show me all registered Tera filters and functions"
+- "How does `generate_toc` work?"
+- "What page metadata fields can I use in my theme?"
+
+**General:**
+- "What commands does lith have?"
+- "How do I configure content schemas?"
+- "Search docs for draft handling"
+- "How does the build pipeline work?"
 
 ## See Also
 

--- a/norgolith-mcp/README.md
+++ b/norgolith-mcp/README.md
@@ -1,0 +1,62 @@
+# Norgolith MCP Server
+
+MCP (Model Context Protocol) server for Norgolith documentation. Lets AI assistants browse, read, and search Norgolith docs directly.
+
+## Installation
+
+Build from source:
+
+```bash
+cargo build --release -p norgolith-mcp
+```
+
+The binary is at `target/release/norgolith-mcp`.
+
+## Configuration
+
+Add to your MCP client config (e.g., `opencode.json`):
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "norgolith": {
+      "type": "local",
+      "command": "norgolith-mcp",
+      "enabled": true
+    }
+  }
+}
+```
+
+Make sure `norgolith-mcp` is in your `PATH`, or use the full path to the binary.
+
+## Resources
+
+Each documentation page is available as a resource with URI `norgolith://{path}` and MIME type `text/x-norg`.
+
+| URI | Description |
+| --- | ----------- |
+| `norgolith://docs/commands` | CLI commands reference |
+| `norgolith://docs/configuration` | Site configuration reference |
+| `norgolith://docs/content-schemas` | Content schema validation |
+| `norgolith://docs/contributing` | Contributing guide |
+| `norgolith://docs/getting-started` | Quick start guide |
+| `norgolith://docs/index` | Documentation index |
+| `norgolith://docs/installation` | Installation guide |
+| `norgolith://docs/plugins` | Plugin development guide |
+| `norgolith://docs/templating` | Templating reference |
+| `norgolith://docs/templating-migration` | Tera v2 migration guide |
+| `norgolith://docs/theming` | Theming guide |
+| `norgolith://index` | Site landing page |
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `search_docs(query)` | Search all documentation for a query string |
+
+## See Also
+
+- [Norgolith documentation](https://norgolith.dev/docs)
+- [Norgolith repository](https://github.com/norgolith/core)

--- a/norgolith-mcp/build.rs
+++ b/norgolith-mcp/build.rs
@@ -1,0 +1,70 @@
+use std::env;
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let docs_dir = Path::new(&manifest_dir).join("../docs/content");
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest = Path::new(&out_dir).join("docs.rs");
+
+    let mut entries = vec![];
+
+    if docs_dir.exists() {
+        let docs_sub = docs_dir.join("docs");
+        if docs_sub.exists() {
+            walk_dir(&docs_sub, &docs_sub, &mut entries);
+        }
+        let index = docs_dir.join("index.norg");
+        if index.exists() {
+            let abs = index.to_string_lossy().to_string();
+            entries.push(("index".into(), "norgolith://index".into(), abs));
+            println!("cargo:rerun-if-changed={}", index.display());
+        }
+    }
+
+    for (_, _, abs_path) in &entries {
+        println!("cargo:rerun-if-changed={}", abs_path);
+    }
+
+    let mut code = String::from(
+        "#[derive(Clone, Copy)]\n\
+         pub struct DocEntry {\n\
+         \tpub name: &'static str,\n\
+         \tpub uri: &'static str,\n\
+         \tpub content: &'static str,\n\
+         }\n\n\
+         pub const DOC_ENTRIES: &[DocEntry] = &[\n",
+    );
+
+    for (name, uri, abs_path) in &entries {
+        let escaped = abs_path.replace('\\', "\\\\");
+        code.push_str(&format!(
+            "\tDocEntry {{ name: {name:?}, uri: {uri:?}, content: include_str!({escaped:?}) }},\n",
+        ));
+    }
+
+    code.push_str("];\n");
+
+    fs::write(&dest, &code).unwrap();
+}
+
+fn walk_dir(base: &Path, dir: &Path, entries: &mut Vec<(String, String, String)>) {
+    for entry in fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
+            walk_dir(base, &path, entries);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("norg") {
+            let rel = path
+                .strip_prefix(base)
+                .unwrap()
+                .with_extension("");
+            let rel_str = rel.to_string_lossy().to_string();
+            let name = rel_str.replace('/', "-");
+            let uri = format!("norgolith://docs/{}", rel_str);
+            let abs_path = path.to_string_lossy().to_string();
+            entries.push((name, uri, abs_path));
+        }
+    }
+}

--- a/norgolith-mcp/build.rs
+++ b/norgolith-mcp/build.rs
@@ -4,22 +4,38 @@ use std::path::Path;
 
 fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let docs_dir = Path::new(&manifest_dir).join("../docs/content");
+    let repo_root = Path::new(&manifest_dir).join("..");
+    let canonical_root = repo_root.canonicalize().unwrap();
+    println!("cargo:rustc-env=NORGOLITH_ROOT={}", canonical_root.display());
+
+    let docs_dir = repo_root.join("docs/content");
     let out_dir = env::var("OUT_DIR").unwrap();
     let dest = Path::new(&out_dir).join("docs.rs");
 
     let mut entries = vec![];
 
+    // Doc resources
     if docs_dir.exists() {
         let docs_sub = docs_dir.join("docs");
         if docs_sub.exists() {
-            walk_dir(&docs_sub, &docs_sub, &mut entries);
+            walk_dir(&docs_sub, &docs_sub, "docs", &mut entries);
         }
         let index = docs_dir.join("index.norg");
         if index.exists() {
             let abs = index.to_string_lossy().to_string();
             entries.push(("index".into(), "norgolith://index".into(), abs));
             println!("cargo:rerun-if-changed={}", index.display());
+        }
+    }
+
+    // Source resources for plugin development
+    let source_dirs = [
+        ("sdk", repo_root.join("sdk/src")),
+        ("core/plugin", repo_root.join("core/src/plugin")),
+    ];
+    for (prefix, dir) in &source_dirs {
+        if dir.exists() {
+            walk_source(dir, dir, prefix, &mut entries);
         }
     }
 
@@ -49,20 +65,37 @@ fn main() {
     fs::write(&dest, &code).unwrap();
 }
 
-fn walk_dir(base: &Path, dir: &Path, entries: &mut Vec<(String, String, String)>) {
+fn walk_dir(base: &Path, dir: &Path, prefix: &str, entries: &mut Vec<(String, String, String)>) {
     for entry in fs::read_dir(dir).unwrap() {
         let entry = entry.unwrap();
         let path = entry.path();
         if path.is_dir() {
-            walk_dir(base, &path, entries);
+            walk_dir(base, &path, prefix, entries);
         } else if path.extension().and_then(|s| s.to_str()) == Some("norg") {
             let rel = path
                 .strip_prefix(base)
                 .unwrap()
                 .with_extension("");
             let rel_str = rel.to_string_lossy().to_string();
-            let name = rel_str.replace('/', "-");
-            let uri = format!("norgolith://docs/{}", rel_str);
+            let name = format!("{}-{}", prefix, rel_str.replace('/', "-"));
+            let uri = format!("norgolith://{}/{}", prefix, rel_str);
+            let abs_path = path.to_string_lossy().to_string();
+            entries.push((name, uri, abs_path));
+        }
+    }
+}
+
+fn walk_source(base: &Path, dir: &Path, prefix: &str, entries: &mut Vec<(String, String, String)>) {
+    for entry in fs::read_dir(dir).unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
+            walk_source(base, &path, prefix, entries);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("rs") {
+            let rel = path.strip_prefix(base).unwrap();
+            let rel_str = rel.to_string_lossy().to_string();
+            let name = format!("{}-{}", prefix, rel_str.replace('/', "-").replace(".rs", ""));
+            let uri = format!("norgolith://src/{}/{}", prefix, rel_str);
             let abs_path = path.to_string_lossy().to_string();
             entries.push((name, uri, abs_path));
         }

--- a/norgolith-mcp/build.rs
+++ b/norgolith-mcp/build.rs
@@ -28,10 +28,12 @@ fn main() {
         }
     }
 
-    // Source resources for plugin development
+    // Source resources for plugin and theme development
     let source_dirs = [
         ("sdk", repo_root.join("sdk/src")),
         ("core/plugin", repo_root.join("core/src/plugin")),
+        ("core/shared", repo_root.join("core/src/shared")),
+        ("core/tera", repo_root.join("core/src/tera")),
     ];
     for (prefix, dir) in &source_dirs {
         if dir.exists() {

--- a/norgolith-mcp/src/main.rs
+++ b/norgolith-mcp/src/main.rs
@@ -1,5 +1,6 @@
 use serde_json::{json, Value};
 use std::io::{self, BufRead, Write};
+use std::path::Path;
 
 include!(concat!(env!("OUT_DIR"), "/docs.rs"));
 
@@ -80,10 +81,15 @@ fn handle_resources_list() -> Value {
     let resources: Vec<Value> = DOC_ENTRIES
         .iter()
         .map(|e| {
+            let mime = if e.uri.starts_with("norgolith://src/") {
+                "text/x-rust"
+            } else {
+                "text/x-norg"
+            };
             json!({
                 "uri": e.uri,
                 "name": e.name,
-                "mimeType": "text/x-norg"
+                "mimeType": mime,
             })
         })
         .collect();
@@ -96,10 +102,15 @@ fn handle_resources_read(req: &Value) -> Value {
 
     for entry in DOC_ENTRIES {
         if entry.uri == uri {
+            let mime = if uri.starts_with("norgolith://src/") {
+                "text/x-rust"
+            } else {
+                "text/x-norg"
+            };
             return json!({
                 "contents": [{
                     "uri": entry.uri,
-                    "mimeType": "text/x-norg",
+                    "mimeType": mime,
                     "text": entry.content
                 }]
             });
@@ -111,20 +122,36 @@ fn handle_resources_read(req: &Value) -> Value {
 
 fn handle_tools_list() -> Value {
     json!({
-        "tools": [{
-            "name": "search_docs",
-            "description": "Search Norgolith documentation content",
-            "inputSchema": {
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "Search query to find in documentation"
-                    }
-                },
-                "required": ["query"]
+        "tools": [
+            {
+                "name": "search_docs",
+                "description": "Search Norgolith documentation content",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Search query to find in documentation"
+                        }
+                    },
+                    "required": ["query"]
+                }
+            },
+            {
+                "name": "read_source",
+                "description": "Read a source file from the norgolith repository",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Relative path from repo root (e.g., core/src/plugin/mod.rs)"
+                        }
+                    },
+                    "required": ["path"]
+                }
             }
-        }]
+        ]
     })
 }
 
@@ -132,10 +159,14 @@ fn handle_tools_call(req: &Value) -> Value {
     let name = req["params"]["name"].as_str().unwrap_or("");
     let args = &req["params"]["arguments"];
 
-    if name != "search_docs" {
-        return json!({"error": {"code": -32602, "message": format!("Unknown tool: {}", name)}});
+    match name {
+        "search_docs" => call_search_docs(args),
+        "read_source" => call_read_source(args),
+        _ => json!({"error": {"code": -32602, "message": format!("Unknown tool: {}", name)}}),
     }
+}
 
+fn call_search_docs(args: &Value) -> Value {
     let query = args["query"].as_str().unwrap_or("").to_lowercase();
     if query.is_empty() {
         return json!({
@@ -178,4 +209,32 @@ fn handle_tools_call(req: &Value) -> Value {
     json!({
         "content": [{"type": "text", "text": text}]
     })
+}
+
+fn call_read_source(args: &Value) -> Value {
+    let path = args["path"].as_str().unwrap_or("");
+    if path.is_empty() {
+        return json!({
+            "content": [{"type": "text", "text": "No path provided."}]
+        });
+    }
+
+    let root = match option_env!("NORGOLITH_ROOT") {
+        Some(r) => r,
+        None => return json!({
+            "content": [{"type": "text", "text": "Repository root not embedded. This tool only works in the norgolith repository."}]
+        }),
+    };
+
+    let full_path = Path::new(root).join(path);
+
+    // XXX: no path traversal protection. Only runs in trusted monorepo context.
+    match std::fs::read_to_string(&full_path) {
+        Ok(content) => json!({
+            "content": [{"type": "text", "text": content}]
+        }),
+        Err(e) => json!({
+            "content": [{"type": "text", "text": format!("Could not read {}: {}", path, e)}]
+        }),
+    }
 }

--- a/norgolith-mcp/src/main.rs
+++ b/norgolith-mcp/src/main.rs
@@ -1,0 +1,181 @@
+use serde_json::{json, Value};
+use std::io::{self, BufRead, Write};
+
+include!(concat!(env!("OUT_DIR"), "/docs.rs"));
+
+fn main() {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let req: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let method = req["method"].as_str().unwrap_or("");
+        let id = &req["id"];
+
+        let response = match method {
+            "initialize" => handle_initialize(&req),
+            "ping" => wrap(id, json!({})),
+            "notifications/initialized" => continue,
+            "resources/list" => wrap(id, handle_resources_list()),
+            "resources/read" => wrap(id, handle_resources_read(&req)),
+            "tools/list" => wrap(id, handle_tools_list()),
+            "tools/call" => wrap(id, handle_tools_call(&req)),
+            _ => {
+                if id.is_null() {
+                    continue;
+                }
+                json!({"jsonrpc": "2.0", "id": id, "error": {"code": -32601, "message": "Method not found"}})
+            }
+        };
+
+        if id.is_null() {
+            continue;
+        }
+
+        let mut out = stdout.lock();
+        let _ = writeln!(out, "{}", serde_json::to_string(&response).unwrap());
+        let _ = out.flush();
+    }
+}
+
+fn wrap(id: &Value, result: Value) -> Value {
+    if let Some(err) = result.get("error") {
+        return json!({"jsonrpc": "2.0", "id": id, "error": err});
+    }
+    json!({"jsonrpc": "2.0", "id": id, "result": result})
+}
+
+fn handle_initialize(req: &Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": req["id"],
+        "result": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {
+                "resources": {},
+                "tools": {}
+            },
+            "serverInfo": {
+                "name": "norgolith-mcp",
+                "version": "1.0.0"
+            }
+        }
+    })
+}
+
+fn handle_resources_list() -> Value {
+    let resources: Vec<Value> = DOC_ENTRIES
+        .iter()
+        .map(|e| {
+            json!({
+                "uri": e.uri,
+                "name": e.name,
+                "mimeType": "text/x-norg"
+            })
+        })
+        .collect();
+
+    json!({"resources": resources})
+}
+
+fn handle_resources_read(req: &Value) -> Value {
+    let uri = req["params"]["uri"].as_str().unwrap_or("");
+
+    for entry in DOC_ENTRIES {
+        if entry.uri == uri {
+            return json!({
+                "contents": [{
+                    "uri": entry.uri,
+                    "mimeType": "text/x-norg",
+                    "text": entry.content
+                }]
+            });
+        }
+    }
+
+    json!({"error": {"code": -32602, "message": format!("Resource not found: {}", uri)}})
+}
+
+fn handle_tools_list() -> Value {
+    json!({
+        "tools": [{
+            "name": "search_docs",
+            "description": "Search Norgolith documentation content",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search query to find in documentation"
+                    }
+                },
+                "required": ["query"]
+            }
+        }]
+    })
+}
+
+fn handle_tools_call(req: &Value) -> Value {
+    let name = req["params"]["name"].as_str().unwrap_or("");
+    let args = &req["params"]["arguments"];
+
+    if name != "search_docs" {
+        return json!({"error": {"code": -32602, "message": format!("Unknown tool: {}", name)}});
+    }
+
+    let query = args["query"].as_str().unwrap_or("").to_lowercase();
+    if query.is_empty() {
+        return json!({
+            "content": [{"type": "text", "text": "No query provided."}]
+        });
+    }
+
+    let mut results = Vec::new();
+
+    for entry in DOC_ENTRIES {
+        for (i, line) in entry.content.lines().enumerate() {
+            if line.to_lowercase().contains(&query) {
+                let line_num = i + 1;
+                let snippet = line.trim();
+                if snippet.len() > 120 {
+                    let truncated: String = snippet.chars().take(120).collect();
+                    results.push(format!("{}:{}: {}...", entry.uri, line_num, truncated));
+                } else {
+                    results.push(format!("{}:{}: {}", entry.uri, line_num, snippet));
+                }
+            }
+        }
+    }
+
+    if results.is_empty() {
+        return json!({
+            "content": [{"type": "text", "text": format!("No results found for: {}", query)}]
+        });
+    }
+
+    // XXX: cap at 50 results to avoid huge responses
+    let text = if results.len() > 50 {
+        results.truncate(50);
+        format!("{} (showing first 50 results)\n\n", results.len())
+            + &results.join("\n")
+    } else {
+        results.join("\n")
+    };
+
+    json!({
+        "content": [{"type": "text", "text": text}]
+    })
+}


### PR DESCRIPTION
Add norgolith-mcp crate, an MCP server that serves Norgolith docs as resources and provides a search_docs tool. Docs are embedded at compile time for zero runtime filesystem dependency. Includes a Nix package in the flake.

It also has plugin-related source code files embedded for helping with plugins development, and theme-related source code files embedded for helping with theming development.

If the MCP is used within the Norgolith monorepo, it can also read source code files in order to explain them and so on.