### PR TITLE
feat: add progress bars with indicatif

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,25 +1995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minify-html"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644c1511457e5f70dcbc03c932d4bd26351eceb8657b119c919dde2e65b6d120"
-dependencies = [
- "ahash 0.8.12",
- "aho-corasick 1.1.4",
- "lightningcss",
- "memchr",
- "minify-html-common",
- "once_cell",
- "oxc_allocator",
- "oxc_codegen",
- "oxc_minifier",
- "oxc_parser",
- "oxc_span",
-]
-
-[[package]]
 name = "minify-html-common"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2007,25 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "minify-html-onepass"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dce1cd3c524c89ba96da5e4e19f6eee49fd063795cf273c21608482d6839eaf"
+dependencies = [
+ "ahash 0.8.12",
+ "aho-corasick 1.1.4",
+ "lightningcss",
+ "memchr",
+ "minify-html-common",
+ "once_cell",
+ "oxc_allocator",
+ "oxc_codegen",
+ "oxc_minifier",
+ "oxc_parser",
+ "oxc_span",
 ]
 
 [[package]]
@@ -2142,7 +2142,7 @@ dependencies = [
  "local-ip-address",
  "miette",
  "mime_guess",
- "minify-html",
+ "minify-html-onepass",
  "minify-js",
  "norgolith-plugin-sdk",
  "notify",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,6 +469,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-str"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +930,12 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1522,6 +1540,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,6 +2132,7 @@ dependencies = [
  "git2",
  "html-escape",
  "hyper",
+ "indicatif",
  "indoc",
  "inquire",
  "landlock",
@@ -4061,6 +4093,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4264,6 +4302,16 @@ name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -64,6 +64,7 @@ ureq = { version = "3.3.0", features = ["json"] }
 tar = "0.4.46"
 flate2 = "1.1.9"
 norgolith-plugin-sdk = { path = "../sdk" }
+indicatif = "0.18.6"
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,7 +37,7 @@ mime_guess = "2.0.5"
 tokio-tungstenite = "0.26.1"
 futures-util = { version = "0.3.31", features = ["sink"] }
 walkdir = "2.5.0"
-minify-html = "0.18.1"
+minify-html-onepass = "0.18.1"
 minify-js = "0.6.0"
 regex = "1.11.1"
 semver = { version = "1.0.25", features = ["serde"] }

--- a/core/src/cmd/build/assets.rs
+++ b/core/src/cmd/build/assets.rs
@@ -14,19 +14,30 @@ pub(super) fn should_minify_asset(src: &Path) -> bool {
     !file_stem.ends_with(".min") && (file_ext == "js" || file_ext == "css")
 }
 
-fn minify_html_cfg() -> &'static minify_html::Cfg {
-    static CFG: OnceLock<minify_html::Cfg> = OnceLock::new();
-    CFG.get_or_init(|| minify_html::Cfg {
+fn minify_html_cfg() -> &'static minify_html_onepass::Cfg {
+    static CFG: OnceLock<minify_html_onepass::Cfg> = OnceLock::new();
+    CFG.get_or_init(|| minify_html_onepass::Cfg {
         minify_js: true,
         minify_css: true,
-        ..minify_html::Cfg::default()
     })
 }
 
 #[instrument]
-pub(super) fn minify_html_content(rendered: String) -> Result<String> {
-    String::from_utf8(minify_html::minify(rendered.as_bytes(), minify_html_cfg()))
-        .map_err(|e| miette!("{}: {}", "HTML minification failed".bold(), e))
+pub(super) fn minify_html_content(mut rendered: String) -> Result<String> {
+    let new_len = minify_html_onepass::in_place(
+        unsafe { rendered.as_bytes_mut() },
+        minify_html_cfg(),
+    )
+    .map_err(|e| {
+        miette!(
+            "{} at position {}: {:?}",
+            "HTML minification failed".bold(),
+            e.position,
+            e.error_type
+        )
+    })?;
+    rendered.truncate(new_len);
+    Ok(rendered)
 }
 
 #[instrument(skip(src_path, dest_path))]

--- a/core/src/cmd/build/mod.rs
+++ b/core/src/cmd/build/mod.rs
@@ -25,8 +25,21 @@ use assets::copy_assets;
 use content::{build_category_pages, build_error_pages, generate_xml_feeds};
 use timings::BuildTimings;
 
+#[derive(Default)]
+pub(super) struct PageTimings {
+    pub file_ms: u128,
+    pub meta_ms: u128,
+    pub schema_ms: u128,
+    pub draft_ms: u128,
+    pub cache_get_ms: u128,
+    pub load_ms: u128,
+    pub render_ms: u128,
+    pub href_ms: u128,
+    pub minify_ms: u128,
+}
+
 pub(super) type CacheInsert = (PathBuf, String, serde_json::Value);
-pub(super) type BuildResult = Result<Option<(PathBuf, String, String, Option<CacheInsert>)>>;
+pub(super) type BuildResult = Result<Option<(PathBuf, String, String, Option<CacheInsert>, PageTimings)>>;
 
 fn href_root_re() -> &'static regex::Regex {
     static RE: OnceLock<regex::Regex> = OnceLock::new();
@@ -177,14 +190,32 @@ fn build_contents(
     let mut buffered_writes = Vec::new();
     let mut permalinks = Vec::new();
     let mut page_errors = Vec::new();
+    let mut page_sum_file = 0u128;
+    let mut page_sum_meta = 0u128;
+    let mut page_sum_schema = 0u128;
+    let mut page_sum_draft = 0u128;
+    let mut page_sum_cache_get = 0u128;
+    let mut page_sum_load = 0u128;
+    let mut page_sum_render = 0u128;
+    let mut page_sum_href = 0u128;
+    let mut page_sum_minify = 0u128;
     for result in results {
         match result {
-            Ok(Some((public_path, content, permalink, cache_entry))) => {
+            Ok(Some((public_path, content, permalink, cache_entry, pt))) => {
                 buffered_writes.push((public_path, content));
                 permalinks.push(permalink);
                 if let Some((key, content_str, metadata)) = cache_entry {
                     cache.insert(&key, &content_str, metadata);
                 }
+                page_sum_file += pt.file_ms;
+                page_sum_meta += pt.meta_ms;
+                page_sum_schema += pt.schema_ms;
+                page_sum_draft += pt.draft_ms;
+                page_sum_cache_get += pt.cache_get_ms;
+                page_sum_load += pt.load_ms;
+                page_sum_render += pt.render_ms;
+                page_sum_href += pt.href_ms;
+                page_sum_minify += pt.minify_ms;
             }
             Ok(None) => {}
             Err(e) => {
@@ -208,13 +239,21 @@ fn build_contents(
     let write_ms = write_start.elapsed().as_millis();
 
     let mut timings = BuildTimings::new();
+    timings.page_file_ms = page_sum_file / 1000;
+    timings.page_meta_ms = page_sum_meta / 1000;
+    timings.page_schema_ms = page_sum_schema / 1000;
+    timings.page_draft_ms = page_sum_draft / 1000;
+    timings.page_cache_get_ms = page_sum_cache_get / 1000;
+    timings.page_load_ms = page_sum_load / 1000;
+    timings.page_render_ms = page_sum_render / 1000;
+    timings.page_href_ms = page_sum_href / 1000;
+    timings.page_minify_ms = page_sum_minify / 1000;
     timings.page_write_ms = write_ms;
     timings.page_count = built_count;
 
     Ok((built_count, permalinks, timings))
 }
 
-#[instrument(level = "debug", skip(path, ctx, shared_context, cache))]
 fn build_content_entry(
     path: &Path,
     ctx: BuildContext<'_>,
@@ -226,6 +265,7 @@ fn build_content_entry(
         .strip_prefix(&ctx.paths.content)
         .into_diagnostic().wrap_err("Failed to strip prefix")?;
 
+    let t = Instant::now();
     let Ok(content) = std::fs::read_to_string(path) else {
         error!(
             "{} {}",
@@ -234,9 +274,14 @@ fn build_content_entry(
         );
         return Ok(None);
     };
+    let file_ms = t.elapsed().as_micros();
 
+    let t = Instant::now();
     let metadata =
         shared::extract_metadata_from_content(&content, rel_path, &ctx.site_config.root_url)?;
+    let meta_ms = t.elapsed().as_micros();
+
+    let t = Instant::now();
     if let Some(schema) = &ctx.site_config.content_schema
         && !rel_path.starts_with(&ctx.site_config.categories_dir)
     {
@@ -248,7 +293,9 @@ fn build_content_entry(
             false,
         )?;
     }
+    let schema_ms = t.elapsed().as_micros();
 
+    let t = Instant::now();
     let is_draft = match metadata.get("draft") {
         Some(val) => val.as_bool().ok_or_else(|| {
             miette!("'draft' field must be a boolean for '{}'", path.display())
@@ -258,10 +305,15 @@ fn build_content_entry(
     if is_draft {
         return Ok(None);
     }
+    let draft_ms = t.elapsed().as_micros();
 
     let cache_key = rel_path.with_extension("");
-    let cached = cache.get(&cache_key, &content);
 
+    let t = Instant::now();
+    let cached = cache.get(&cache_key, &content);
+    let cache_get_ms = t.elapsed().as_micros();
+
+    let t = Instant::now();
     let (mut metadata, cache_insert) = if let Some(cached) = cached {
         match serde_json::from_value::<toml::Value>(cached.clone()) {
             Ok(md) => (md, None),
@@ -280,6 +332,7 @@ fn build_content_entry(
         let cache_val = serde_json::to_value(&md).unwrap_or_default();
         (md, Some((cache_key, content.clone(), cache_val)))
     };
+    let load_ms = t.elapsed().as_micros();
 
     ctx.plugins
         .run_post_convert(ctx.site_config, &mut metadata, rel_path);
@@ -301,22 +354,28 @@ fn build_content_entry(
 
     let public_path = determine_public_path(&ctx.paths.public, rel_path)?;
 
+    let t = Instant::now();
     let mut rendered = shared::render_norg_page(ctx.tera, &metadata, shared_context)?;
+    let render_ms = t.elapsed().as_micros();
 
     rendered = ctx
         .plugins
         .run_post_render(ctx.site_config, rendered, &metadata, rel_path);
 
+    let t = Instant::now();
     let href_re = href_root_re();
     rendered = href_re
         .replace_all(&rendered, format!("href=\"{}/", ctx.site_config.root_url))
         .into_owned();
+    let href_ms = t.elapsed().as_micros();
 
+    let t = Instant::now();
     let rendered = if minify && !rendered.is_empty() {
         assets::minify_html_content(rendered)?
     } else {
         rendered
     };
+    let minify_ms = t.elapsed().as_micros();
 
     let permalink = metadata
         .get("permalink")
@@ -324,7 +383,19 @@ fn build_content_entry(
         .unwrap_or("/")
         .to_string();
 
-    Ok(Some((public_path, rendered, permalink, cache_insert)))
+    let pt = PageTimings {
+        file_ms,
+        meta_ms,
+        schema_ms,
+        draft_ms,
+        cache_get_ms,
+        load_ms,
+        render_ms,
+        href_ms,
+        minify_ms,
+    };
+
+    Ok(Some((public_path, rendered, permalink, cache_insert, pt)))
 }
 
 #[instrument(skip(minify))]
@@ -474,6 +545,15 @@ pub fn build(minify: bool) -> Result<()> {
         build_contents(ctx, &shared_context, &mut cache, minify, &mp)?;
     timings.content_ms = t.elapsed().as_millis();
     timings.page_count = page_count;
+    timings.page_file_ms = content_timings.page_file_ms;
+    timings.page_meta_ms = content_timings.page_meta_ms;
+    timings.page_schema_ms = content_timings.page_schema_ms;
+    timings.page_draft_ms = content_timings.page_draft_ms;
+    timings.page_cache_get_ms = content_timings.page_cache_get_ms;
+    timings.page_load_ms = content_timings.page_load_ms;
+    timings.page_render_ms = content_timings.page_render_ms;
+    timings.page_href_ms = content_timings.page_href_ms;
+    timings.page_minify_ms = content_timings.page_minify_ms;
     timings.page_write_ms = content_timings.page_write_ms;
     mp.println(format!(
         "  {} {}  {:<12}  {}",

--- a/core/src/cmd/build/mod.rs
+++ b/core/src/cmd/build/mod.rs
@@ -1,6 +1,6 @@
 mod assets;
 mod content;
-mod progress;
+pub mod progress;
 mod timings;
 
 use std::{

--- a/core/src/cmd/build/mod.rs
+++ b/core/src/cmd/build/mod.rs
@@ -1,5 +1,6 @@
 mod assets;
 mod content;
+mod progress;
 mod timings;
 
 use std::{
@@ -9,12 +10,14 @@ use std::{
 };
 
 use colored::{ColoredString, Colorize};
+use indicatif::MultiProgress;
 use miette::{IntoDiagnostic, NamedSource, Result, WrapErr, bail, miette};
 use tera::Context;
 use tracing::{debug, error, instrument, warn};
 use walkdir::WalkDir;
 
 use super::seo;
+use progress::{make_bar, make_spinner};
 use crate::shared::{BuildContext, SitePaths};
 use crate::{cache::BuildCache, config, fs, plugin, shortcode, shared};
 
@@ -137,12 +140,13 @@ fn write_public_file(public_path: &Path, rendered: &str) -> Result<bool> {
     Ok(true)
 }
 
-#[instrument(level = "debug", skip(ctx, shared_context, cache))]
+#[instrument(level = "debug", skip(ctx, shared_context, cache, mp))]
 fn build_contents(
     ctx: BuildContext<'_>,
     shared_context: &Context,
     cache: &mut BuildCache,
     minify: bool,
+    mp: &MultiProgress,
 ) -> Result<(usize, Vec<String>, BuildTimings)> {
     use rayon::prelude::*;
 
@@ -158,13 +162,17 @@ fn build_contents(
         .filter(|e| e.path().extension().is_some_and(|ext| ext == "norg"))
         .collect();
 
+    let bar = make_bar(mp, entries.len() as u64, "Building content");
+
     let results: Vec<BuildResult> = entries
         .par_iter()
         .map(|entry| {
             let path = entry.path();
+            bar.inc(1);
             build_content_entry(path, ctx, shared_context, cache, minify)
         })
         .collect();
+    bar.finish_and_clear();
 
     let mut buffered_writes = Vec::new();
     let mut permalinks = Vec::new();
@@ -328,7 +336,8 @@ pub fn build(minify: bool) -> Result<()> {
         );
     };
 
-    println!(
+    let mp = MultiProgress::new();
+    mp.println(format!(
         "{} Building site{}...",
         "→".cyan().bold(),
         if minify {
@@ -336,7 +345,7 @@ pub fn build(minify: bool) -> Result<()> {
         } else {
             ColoredString::from("")
         }
-    );
+    )).ok();
     let build_start = Instant::now();
     let mut timings = BuildTimings::new();
 
@@ -386,14 +395,13 @@ pub fn build(minify: bool) -> Result<()> {
     }
     timings.plugins_ms = t.elapsed().as_millis();
 
-    println!();
     if !plugin_mgr.is_empty() {
-        println!(
+        mp.println(format!(
             "  {} {}  {} plugins",
             "•".green(),
             format!("{:<12}", "Plugins").bold(),
             plugin_mgr.len()
-        );
+        )).ok();
     }
 
     // pre_build hook
@@ -425,6 +433,7 @@ pub fn build(minify: bool) -> Result<()> {
 
     // Collect post metadata
     let t = Instant::now();
+    let meta_spinner = make_spinner(&mp, "Collecting posts metadata");
     let posts: Vec<_> = shared::collect_all_posts_metadata(
         &paths.content,
         &site_config.root_url,
@@ -436,6 +445,7 @@ pub fn build(minify: bool) -> Result<()> {
     })
     .collect();
     timings.collect_posts_ms = t.elapsed().as_millis();
+    meta_spinner.finish_and_clear();
 
     // Pre-compute collection subsets
     let t = Instant::now();
@@ -461,30 +471,30 @@ pub fn build(minify: bool) -> Result<()> {
         plugins: &plugin_mgr,
     };
     let (page_count, permalinks, content_timings) =
-        build_contents(ctx, &shared_context, &mut cache, minify)?;
+        build_contents(ctx, &shared_context, &mut cache, minify, &mp)?;
     timings.content_ms = t.elapsed().as_millis();
     timings.page_count = page_count;
     timings.page_write_ms = content_timings.page_write_ms;
-    println!(
+    mp.println(format!(
         "  {} {}  {:<12}  {}",
         "•".green(),
         format!("{:<12}", "Content").bold(),
         format!("{} pages", page_count),
         shared::get_elapsed_time(t).dimmed()
-    );
+    )).ok();
 
     // Category pages
     let t = Instant::now();
     let cat_count = build_category_pages(&tera, &paths.public, &posts, &site_config, &collections)?;
     timings.categories_ms = t.elapsed().as_millis();
     if cat_count > 0 {
-        println!(
+        mp.println(format!(
             "  {} {}  {:<12}  {}",
             "•".green(),
             format!("{:<12}", "Categories").bold(),
             format!("{} pages", cat_count),
             shared::get_elapsed_time(t).dimmed()
-        );
+        )).ok();
     }
 
     // XML feeds
@@ -492,13 +502,13 @@ pub fn build(minify: bool) -> Result<()> {
     let (feed_count, feed_names) = generate_xml_feeds(&tera, &shared_context, &paths.public)?;
     timings.feeds_ms = t.elapsed().as_millis();
     if feed_count > 0 {
-        println!(
+        mp.println(format!(
             "  {} {}  {:<12}  {}",
             "•".green(),
             format!("{:<12}", "Feeds").bold(),
             format!("{} files", feed_count),
             shared::get_elapsed_time(t).dimmed()
-        );
+        )).ok();
     }
 
     // SEO generation
@@ -573,13 +583,13 @@ pub fn build(minify: bool) -> Result<()> {
     }
     timings.seo_ms = t.elapsed().as_millis();
     if seo_count > 0 {
-        println!(
+        mp.println(format!(
             "  {} {}  {:<12}  {}",
             "•".green(),
             format!("{:<12}", "SEO").bold(),
             format!("{} files", seo_count),
             shared::get_elapsed_time(t).dimmed()
-        );
+        )).ok();
     }
 
     // Assets
@@ -591,26 +601,26 @@ pub fn build(minify: bool) -> Result<()> {
     }
     asset_count += copy_assets(&paths.assets, &public_assets_dir, minify)?;
     timings.assets_ms = t.elapsed().as_millis();
-    println!(
+    mp.println(format!(
         "  {} {}  {:<12}  {}",
         "•".green(),
         format!("{:<12}", "Assets").bold(),
         format!("{} files", asset_count),
         shared::get_elapsed_time(t).dimmed()
-    );
+    )).ok();
 
     // Error pages
     let t = Instant::now();
     let error_page_count = build_error_pages(&tera, &shared_context, &paths.public)?;
     timings.error_pages_ms = t.elapsed().as_millis();
     if error_page_count > 0 {
-        println!(
+        mp.println(format!(
             "  {} {}  {:<12}  {}",
             "•".green(),
             format!("{:<12}", "Error pages").bold(),
             format!("{} files", error_page_count),
             shared::get_elapsed_time(t).dimmed()
-        );
+        )).ok();
     }
 
     // post_build hook
@@ -630,6 +640,7 @@ pub fn build(minify: bool) -> Result<()> {
         }
     }
 
+    drop(mp);
     println!();
     let total_ms = build_start.elapsed().as_millis();
     println!(

--- a/core/src/cmd/build/progress.rs
+++ b/core/src/cmd/build/progress.rs
@@ -1,0 +1,21 @@
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+
+pub fn make_bar(mp: &MultiProgress, len: u64, msg: &str) -> ProgressBar {
+    let bar = mp.add(ProgressBar::new(len));
+    bar.set_style(
+        ProgressStyle::with_template("{spinner:.green} {msg} [{bar:30.cyan/blue}] {pos}/{len}")
+            .unwrap()
+            .progress_chars("=> "),
+    );
+    bar.enable_steady_tick(std::time::Duration::from_millis(120));
+    bar.set_message(msg.to_string());
+    bar
+}
+
+pub fn make_spinner(mp: &MultiProgress, msg: &str) -> ProgressBar {
+    let bar = mp.add(ProgressBar::new_spinner());
+    bar.set_style(ProgressStyle::with_template("{spinner:.green} {msg}").unwrap());
+    bar.enable_steady_tick(std::time::Duration::from_millis(120));
+    bar.set_message(msg.to_string());
+    bar
+}

--- a/core/src/cmd/dev/mod.rs
+++ b/core/src/cmd/dev/mod.rs
@@ -47,8 +47,8 @@ pub async fn dev(
     } else {
         format!("http://localhost:{}", port)
     };
-    let state = setup_server_state(root, drafts, routes_url).await?;
     let server_start = std::time::Instant::now();
+    let state = setup_server_state(root, drafts, routes_url).await?;
     let rt = Handle::current();
 
     let _guard_receiver = state.reload_tx.subscribe();

--- a/core/src/cmd/dev/mod.rs
+++ b/core/src/cmd/dev/mod.rs
@@ -117,21 +117,21 @@ pub async fn dev(
         });
 
     let localhost_address = format!(
-        "{} {}   {}",
+        "  {} {}   {}",
         "•".green(),
         "Local:".bold(),
         format!("http://localhost:{}/", port.to_string().cyan().bold()).blue()
     );
     let lan_address = if host {
         format!(
-            "{} {} {}",
+            "  {} {} {}",
             "•".green(),
             "Network:".bold(),
             format!("http://{}:{}/", local_ip, port.to_string().cyan().bold()).blue()
         )
     } else {
         format!(
-            "{} {} {} {} {}",
+            "  {} {} {} {} {}",
             "•".green().dimmed(),
             "Network:".bold().dimmed(),
             "use".dimmed(),
@@ -140,7 +140,7 @@ pub async fn dev(
         )
     };
     println!(
-        "Server started in {}\n{}\n{}\n\n{}\n",
+        "\nServer started in {}\n{}\n{}\n\n{}\n",
         shared::get_elapsed_time(server_start),
         localhost_address,
         lan_address,

--- a/core/src/cmd/dev/server.rs
+++ b/core/src/cmd/dev/server.rs
@@ -3,12 +3,14 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use colored::Colorize;
+use indicatif::{MultiProgress, ProgressBar};
 use miette::{IntoDiagnostic, NamedSource, Result, WrapErr, miette};
 use tera::{Context, Tera};
 use tokio::sync::{RwLock, broadcast};
 use tracing::{debug, error, info, instrument, warn};
 use walkdir::WalkDir;
 
+use crate::cmd::build::progress::{make_bar, make_spinner};
 use crate::shared::{BuildContext, SitePaths};
 use crate::{config, plugin, shortcode, shared};
 
@@ -95,6 +97,7 @@ impl ServerState {
             &posts,
             &self.routes_url,
             &cache,
+            None,
         ) {
             Ok(new_pages) => {
                 let mut pages = self.rendered_pages.write().await;
@@ -130,6 +133,7 @@ pub fn render_all_pages(
     posts: &[toml::Value],
     routes_url: &str,
     cache: &crate::cache::BuildCache,
+    progress: Option<&ProgressBar>,
 ) -> Result<HashMap<String, String>> {
     let mut pages = HashMap::new();
 
@@ -206,6 +210,10 @@ pub fn render_all_pages(
 
         let url_path = format!("/{}", rel_path.with_extension("").display());
         pages.insert(url_path, body);
+
+        if let Some(b) = progress {
+            b.inc(1);
+        }
     }
 
     // Pre-render category index
@@ -323,12 +331,25 @@ pub(super) async fn setup_server_state(
 
     let (reload_tx, _) = broadcast::channel(16);
 
+    let mp = MultiProgress::new();
+    let meta_spinner = make_spinner(&mp, "Collecting posts metadata");
+
     let posts =
         shared::collect_all_posts_metadata(&paths.content, &routes_url, &site_config.collections)?;
+
+    meta_spinner.finish_and_clear();
 
     let cache = crate::cache::BuildCache::open(&root_dir)?;
 
     let plugin_mgr = plugin::PluginManager::load(&root_dir);
+    if !plugin_mgr.is_empty() {
+        mp.println(format!(
+            "  {} {}  {} plugins",
+            "•".green(),
+            format!("{:<12}", "Plugins").bold(),
+            plugin_mgr.len()
+        )).ok();
+    }
     if let Err(e) = plugin::sandbox::apply_landlock(&root_dir) {
         warn!("{}", e);
     }
@@ -353,6 +374,14 @@ pub(super) async fn setup_server_state(
         }
     }
 
+    let entry_count: usize = WalkDir::new(&paths.content)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "norg"))
+        .count();
+
+    let render_bar = make_bar(&mp, entry_count as u64, "Loading pages in-memory");
+
     let rendered_pages = render_all_pages(
         BuildContext {
             tera: &tera,
@@ -363,7 +392,11 @@ pub(super) async fn setup_server_state(
         &posts,
         &routes_url,
         &cache,
+        Some(&render_bar),
     )?;
+
+    render_bar.finish_and_clear();
+    drop(mp);
 
     let tera = Arc::new(RwLock::new(tera));
 

--- a/core/src/plugin/mod.rs
+++ b/core/src/plugin/mod.rs
@@ -101,7 +101,6 @@ impl PluginManager {
             let dir = entry.path();
             match load_plugin(&dir) {
                 Ok(instance) => {
-                    info!("Loaded plugin '{}' v{}", instance.name, instance.version);
                     manager.plugins.push(instance);
                 }
                 Err(e) => {

--- a/core/src/shared/metadata.rs
+++ b/core/src/shared/metadata.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use miette::{Result, miette};
+use rayon::prelude::*;
 use tracing::warn;
 use walkdir::WalkDir;
 
@@ -188,7 +189,7 @@ pub fn collect_all_posts_metadata(
 
     // Process metadata extraction
     let mut posts: Vec<toml::Value> = entries
-        .into_iter()
+        .into_par_iter()
         .map(|(path, rel_path)| -> Result<toml::Value> {
             let content = std::fs::read_to_string(&path)
                 .map_err(|_| miette!("Failed to read {}: {}", rel_path.display(), path.display()))?;


### PR DESCRIPTION
- Content phase: live progress bar with file count
- Metadata collection: spinner so CLI doesn't appear frozen
- All phase output routed through MultiProgress for clean rendering
- Remove duplicate per-plugin load line (Plugins count suffices)
- Fixed dev server timing