### PR TITLE
Refactor the flake a little

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1781074563,
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
 
       devShells = eachSystem (pkgs: {
         default = pkgs.mkShell {
-          buildInputs = [
+          nativeBuildInputs = [
             pkgs.rustPlatform.rustLibSrc
 
             pkgs.cargo
@@ -130,10 +130,12 @@
             pkgs.tailwindcss-language-server
           ];
 
-          # Many editors rely on this rust-src PATH variable
-          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+          env = {
+            # Many editors rely on this rust-src PATH variable
+            RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
 
-          PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+            PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+          };
         };
       });
     };

--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,7 @@
         corePackage = (pkgs.lib.importTOML "${self}/core/Cargo.toml").package;
         sdkPackage = (pkgs.lib.importTOML "${self}/sdk/Cargo.toml").package;
         mcpPackage = (pkgs.lib.importTOML "${self}/norgolith-mcp/Cargo.toml").package;
-      in
-      rec {
+      in {
         formatter = pkgs.nixfmt-tree;
 
         # nix build
@@ -107,7 +106,7 @@
         };
 
         # nix run
-        apps.default = flake-utils.lib.mkApp { drv = packages.default; };
+        apps.default = flake-utils.lib.mkApp { drv = self.packages.default; };
 
         # nix develop
         devShells.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -6,25 +6,31 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-    ...
-  }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      ...
+    }:
     flake-utils.lib.eachDefaultSystem (
-      system: let
-        pkgs = import nixpkgs {inherit system;};
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
         toolchain = pkgs.rustPlatform;
         corePackage = (pkgs.lib.importTOML "${self}/core/Cargo.toml").package;
         sdkPackage = (pkgs.lib.importTOML "${self}/sdk/Cargo.toml").package;
         mcpPackage = (pkgs.lib.importTOML "${self}/norgolith-mcp/Cargo.toml").package;
-      in rec {
+      in
+      rec {
+        formatter = pkgs.nixfmt-tree;
+
         # nix build
         packages.default = toolchain.buildRustPackage {
           pname = corePackage.name;
           version = corePackage.version;
           src = pkgs.lib.cleanSource "${self}";
+
           cargoLock = {
             lockFile = "${self}/Cargo.lock";
             allowBuiltinFetchGit = true;
@@ -63,6 +69,7 @@
           pname = sdkPackage.name;
           version = sdkPackage.version;
           src = pkgs.lib.cleanSource "${self}";
+
           cargoLock = {
             lockFile = "${self}/sdk/Cargo.lock";
             allowBuiltinFetchGit = true;
@@ -82,6 +89,7 @@
           pname = mcpPackage.name;
           version = mcpPackage.version;
           src = pkgs.lib.cleanSource "${self}";
+
           cargoLock = {
             lockFile = "${self}/norgolith-mcp/Cargo.lock";
             allowBuiltinFetchGit = true;
@@ -98,7 +106,7 @@
         };
 
         # nix run
-        apps.default = flake-utils.lib.mkApp {drv = packages.default;};
+        apps.default = flake-utils.lib.mkApp { drv = packages.default; };
 
         # nix develop
         devShells.default = pkgs.mkShell {
@@ -132,7 +140,7 @@
     );
 
   nixConfig = {
-    extra-substituters = ["https://ntbbloodbath.cachix.org"];
+    extra-substituters = [ "https://ntbbloodbath.cachix.org" ];
     extra-trusted-public-keys = [
       "ntbbloodbath.cachix.org-1:L4DjjGwDB6O3BJ4SmtYTZbvWKLi+1v/hRlLWKOtq+f0="
     ];

--- a/flake.nix
+++ b/flake.nix
@@ -105,9 +105,6 @@
           };
         };
 
-        # nix run
-        apps.default = flake-utils.lib.mkApp { drv = self.packages.default; };
-
         # nix develop
         devShells.default = pkgs.mkShell {
           buildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -3,112 +3,115 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
   };
 
   outputs =
     {
       self,
       nixpkgs,
-      flake-utils,
       ...
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        toolchain = pkgs.rustPlatform;
-        corePackage = (pkgs.lib.importTOML "${self}/core/Cargo.toml").package;
-        sdkPackage = (pkgs.lib.importTOML "${self}/sdk/Cargo.toml").package;
-        mcpPackage = (pkgs.lib.importTOML "${self}/norgolith-mcp/Cargo.toml").package;
-      in {
-        formatter = pkgs.nixfmt-tree;
+    let
+      systems = nixpkgs.lib.systems.doubles.linux ++ nixpkgs.lib.systems.doubles.darwin;
+      eachSystem = f: nixpkgs.lib.genAttrs systems (s: f nixpkgs.legacyPackages.${s});
+    in
+    {
+      formatter = eachSystem (pkgs: pkgs.nixfmt-tree);
 
-        # nix build
-        packages.default = toolchain.buildRustPackage {
-          pname = corePackage.name;
-          version = corePackage.version;
-          src = pkgs.lib.cleanSource "${self}";
+      packages = eachSystem (
+        pkgs:
+        let
+          corePackage = (pkgs.lib.importTOML "${self}/core/Cargo.toml").package;
+          sdkPackage = (pkgs.lib.importTOML "${self}/sdk/Cargo.toml").package;
+          mcpPackage = (pkgs.lib.importTOML "${self}/norgolith-mcp/Cargo.toml").package;
+        in
+        {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = corePackage.name;
+            version = corePackage.version;
+            src = pkgs.lib.cleanSource "${self}";
 
-          cargoLock = {
-            lockFile = "${self}/Cargo.lock";
-            allowBuiltinFetchGit = true;
+            cargoLock = {
+              lockFile = "${self}/Cargo.lock";
+              allowBuiltinFetchGit = true;
+            };
+            useNextest = true;
+            dontUseCargoParallelTests = true;
+
+            nativeBuildInputs = [
+              pkgs.pkg-config
+            ];
+
+            buildInputs = [
+              pkgs.libgit2
+              pkgs.openssl
+              pkgs.zlib
+            ];
+
+            env = {
+              LIBGIT2_NO_VENDOR = true;
+              OPENSSL_NO_VENDOR = true;
+            };
+
+            __darwinAllowLocalNetworking = true;
+
+            meta = {
+              description = corePackage.description;
+              homepage = corePackage.repository;
+              license = pkgs.lib.licenses.gpl2Only;
+              maintainers = corePackage.authors;
+            };
+
+            # For other makeRustPlatform features see:
+            # https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#cargo-features-cargo-features
           };
-          useNextest = true;
-          dontUseCargoParallelTests = true;
 
-          nativeBuildInputs = [
-            pkgs.pkg-config
-          ];
+          norgolith-plugin-sdk = pkgs.rustPlatform.buildRustPackage {
+            pname = sdkPackage.name;
+            version = sdkPackage.version;
+            src = pkgs.lib.cleanSource "${self}";
 
+            cargoLock = {
+              lockFile = "${self}/sdk/Cargo.lock";
+              allowBuiltinFetchGit = true;
+            };
+            cargoRoot = "sdk";
+            buildAndTestSubdir = "sdk";
+
+            meta = {
+              description = sdkPackage.description;
+              homepage = sdkPackage.repository;
+              license = pkgs.lib.licenses.gpl2Only;
+              maintainers = sdkPackage.authors;
+            };
+          };
+
+          norgolith-mcp = pkgs.rustPlatform.buildRustPackage {
+            pname = mcpPackage.name;
+            version = mcpPackage.version;
+            src = pkgs.lib.cleanSource "${self}";
+
+            cargoLock = {
+              lockFile = "${self}/norgolith-mcp/Cargo.lock";
+              allowBuiltinFetchGit = true;
+            };
+            cargoRoot = "norgolith-mcp";
+            buildAndTestSubdir = "norgolith-mcp";
+
+            meta = {
+              description = mcpPackage.description;
+              homepage = mcpPackage.repository;
+              license = pkgs.lib.licenses.gpl2Only;
+              maintainers = mcpPackage.authors;
+            };
+          };
+        }
+      );
+
+      devShells = eachSystem (pkgs: {
+        default = pkgs.mkShell {
           buildInputs = [
-            pkgs.libgit2
-            pkgs.openssl
-            pkgs.zlib
-          ];
-
-          env = {
-            LIBGIT2_NO_VENDOR = true;
-            OPENSSL_NO_VENDOR = true;
-          };
-
-          __darwinAllowLocalNetworking = true;
-
-          meta = {
-            description = corePackage.description;
-            homepage = corePackage.repository;
-            license = pkgs.lib.licenses.gpl2Only;
-            maintainers = corePackage.authors;
-          };
-
-          # For other makeRustPlatform features see:
-          # https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#cargo-features-cargo-features
-        };
-
-        packages.norgolith-plugin-sdk = toolchain.buildRustPackage {
-          pname = sdkPackage.name;
-          version = sdkPackage.version;
-          src = pkgs.lib.cleanSource "${self}";
-
-          cargoLock = {
-            lockFile = "${self}/sdk/Cargo.lock";
-            allowBuiltinFetchGit = true;
-          };
-          cargoRoot = "sdk";
-          buildAndTestSubdir = "sdk";
-
-          meta = {
-            description = sdkPackage.description;
-            homepage = sdkPackage.repository;
-            license = pkgs.lib.licenses.gpl2Only;
-            maintainers = sdkPackage.authors;
-          };
-        };
-
-        packages.norgolith-mcp = toolchain.buildRustPackage {
-          pname = mcpPackage.name;
-          version = mcpPackage.version;
-          src = pkgs.lib.cleanSource "${self}";
-
-          cargoLock = {
-            lockFile = "${self}/norgolith-mcp/Cargo.lock";
-            allowBuiltinFetchGit = true;
-          };
-          cargoRoot = "norgolith-mcp";
-          buildAndTestSubdir = "norgolith-mcp";
-
-          meta = {
-            description = mcpPackage.description;
-            homepage = mcpPackage.repository;
-            license = pkgs.lib.licenses.gpl2Only;
-            maintainers = mcpPackage.authors;
-          };
-        };
-
-        # nix develop
-        devShells.default = pkgs.mkShell {
-          buildInputs = [
-						toolchain.rustLibSrc
+            pkgs.rustPlatform.rustLibSrc
 
             pkgs.cargo
             pkgs.rustc
@@ -128,12 +131,12 @@
           ];
 
           # Many editors rely on this rust-src PATH variable
-          RUST_SRC_PATH = "${toolchain.rustLibSrc}";
+          RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
 
           PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
         };
-      }
-    );
+      });
+    };
 
   nixConfig = {
     extra-substituters = [ "https://ntbbloodbath.cachix.org" ];

--- a/flake.nix
+++ b/flake.nix
@@ -38,13 +38,14 @@
           useNextest = true;
           dontUseCargoParallelTests = true;
 
-          nativeBuildInputs = with pkgs; [
-            pkg-config
+          nativeBuildInputs = [
+            pkgs.pkg-config
           ];
-          buildInputs = with pkgs; [
-            libgit2
-            openssl
-            zlib
+
+          buildInputs = [
+            pkgs.libgit2
+            pkgs.openssl
+            pkgs.zlib
           ];
 
           env = {
@@ -110,24 +111,24 @@
 
         # nix develop
         devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
+          buildInputs = [
 						toolchain.rustLibSrc
 
-            cargo
-            rustc
-            clippy
-            rustfmt
-            cargo-edit
-            cargo-nextest
-            rust-analyzer
-            pkg-config # Required by git2 crate
-            openssl # Required by git2 crate
+            pkgs.cargo
+            pkgs.rustc
+            pkgs.clippy
+            pkgs.rustfmt
+            pkgs.cargo-edit
+            pkgs.cargo-nextest
+            pkgs.rust-analyzer
+            pkgs.pkg-config # Required by git2 crate
+            pkgs.openssl # Required by git2 crate
 
             # Documentation site dev tools
-            tailwindcss_4
-            mprocs
-            watchman
-            tailwindcss-language-server
+            pkgs.tailwindcss_4
+            pkgs.mprocs
+            pkgs.watchman
+            pkgs.tailwindcss-language-server
           ];
 
           # Many editors rely on this rust-src PATH variable

--- a/flake.nix
+++ b/flake.nix
@@ -111,11 +111,10 @@
         # nix develop
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            (with toolchain; [
-              cargo
-              rustc
-              rustLibSrc
-            ])
+						toolchain.rustLibSrc
+
+            cargo
+            rustc
             clippy
             rustfmt
             cargo-edit


### PR DESCRIPTION
This PR tidies up the flake:
- adds a formatter & formats it
- removes the usage of `with`, which is harmful, shadowing and actually introduced a wrong assumption into the code
- removed a nested list inside `buildInputs` which is deprecated and will be removed

This is preliminary work for my next PR which will be a fix for the fact, that the `libgit2-sys` Rust crate requires libgit2 to be `1.9.6` at least, but the latest unstable version is `1.9.4`. More details in the next PR.