### PR TITLE
Temporarily override libgit2 to build from 1.9.6

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,11 +42,34 @@
               pkgs.pkg-config
             ];
 
-            buildInputs = [
-              pkgs.libgit2
-              pkgs.openssl
-              pkgs.zlib
-            ];
+            buildInputs =
+              let
+                libgit2-196 =
+                  let
+                    overrideObsolete = pkgs.lib.versionAtLeast pkgs.libgit2.version "1.9.6";
+                  in
+                  (
+                    if overrideObsolete then
+                      pkgs.lib.warn "The libgit2 override is no longer needed, `pkgs.libgit2.version`>=`${pkgs.libgit2.version}`." pkgs.libgit2
+                    else
+                      (pkgs.libgit2.overrideAttrs (
+                        f: p: {
+                          version = "1.9.6";
+                          src = pkgs.fetchFromGitHub {
+                            owner = "libgit2";
+                            repo = "libgit2";
+                            tag = "v${f.version}";
+                            hash = "sha256-ogowkZrw9MG4pcgXHzzNX5fm1Z8L2tNW8MDfL4ySJyY=";
+                          };
+                        }
+                      ))
+                  );
+              in
+              [
+                libgit2-196
+                pkgs.openssl
+                pkgs.zlib
+              ];
 
             env = {
               LIBGIT2_NO_VENDOR = true;


### PR DESCRIPTION
This PR adds a temporary override for `pkgs.libgit2` to satisfy rust's `libgit2-sys`, as explained in the commit message.

Do note, that it will build `libgit2` from source, although that should be a quick process.

If you want to go a different way about it, lmk.

btw, the history seems weird, duplicate, but once you rebase the prev. PR it should reconcile properly, I was under the impression that the stacked PRs are a little more streamlined

for the impatient - the patched version can already be used with `github:norgolith/core?ref=pull/215/merge` 