### PR TITLE
Revert nixpkgs libgit2 workaround and fetch nixpkgs differently

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,18 +2,15 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
-        "type": "github"
+        "lastModified": 1787360063,
+        "narHash": "sha256-95aJfHyQTLWslCXFVNB0odgmVkpdmDezQwTg9mhqV1E=",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.11pre1059570.2c423e03bbaf/nixexprs.tar.zst"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.zst"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -43,30 +43,8 @@
             ];
 
             buildInputs =
-              let
-                libgit2-196 =
-                  let
-                    overrideObsolete = pkgs.lib.versionAtLeast pkgs.libgit2.version "1.9.6";
-                  in
-                  (
-                    if overrideObsolete then
-                      pkgs.lib.warn "The libgit2 override is no longer needed, `pkgs.libgit2.version`>=`${pkgs.libgit2.version}`." pkgs.libgit2
-                    else
-                      (pkgs.libgit2.overrideAttrs (
-                        f: p: {
-                          version = "1.9.6";
-                          src = pkgs.fetchFromGitHub {
-                            owner = "libgit2";
-                            repo = "libgit2";
-                            tag = "v${f.version}";
-                            hash = "sha256-ogowkZrw9MG4pcgXHzzNX5fm1Z8L2tNW8MDfL4ySJyY=";
-                          };
-                        }
-                      ))
-                  );
-              in
               [
-                libgit2-196
+                pkgs.libgit2
                 pkgs.openssl
                 pkgs.zlib
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Norg static site generator and plugin SDK";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.zst";
   };
 
   outputs =


### PR DESCRIPTION
As https://nixpk.gs/pr-tracker.html?pr=543272 has hit nixos-unstable, we no longer need to fetch libgit2 directly from the vendor.

And use nixpkgs tarball instead of GitHub nixpkgs. It's lighter because of better compression, and when GitHub is down, the development shell should still work and rebuild if you update it.

I build norgolith with `nix build` and ran `nix develop` on my machine before creating this PR.